### PR TITLE
[levelup] Instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 coverage
+test-db
 build
 notes
 docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
   - "echo \"create keyspace test with replication = {'class':'SimpleStrategy','replication_factor':1};\" | /usr/local/cassandra/bin/cqlsh --cqlversion=3.0.3"
   - npm install -g npm
   - npm install
+  - npm install leveldown
 
 script: "npm test"
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -35,6 +35,11 @@ module.exports = {
     enabled: true,
     collectBacktraces: true
   },
+  levelup: {
+    enabled: true,
+    collectBacktraces: true,
+    enableBatchTracing: false
+  },
   hapi: {
     enabled: true,
     collectBacktraces: true

--- a/lib/probes/levelup.js
+++ b/lib/probes/levelup.js
@@ -1,0 +1,112 @@
+var requirePatch = require('../require-patch')
+var argsToArray = require('sliced')
+var shimmer = require('shimmer')
+var Layer = require('../layer')
+var tv = require('..')
+var conf = tv.levelup
+
+module.exports = function (levelup) {
+  var Batch = requirePatch.relativeRequire('levelup/lib/batch')
+  patch(levelup.prototype)
+  patchBatch(levelup.prototype, Batch)
+  return levelup
+}
+
+function patch (levelup) {
+  var continuations = ['open','close']
+  var operations = ['get','put','del']
+
+  continuations.forEach(function (method) {
+    shimmer.wrap(levelup, method, function (fn) {
+      return function (callback) {
+        if (callback) {
+          callback = tv.requestStore.bind(callback)
+        }
+        return fn.call(this, callback)
+      }
+    })
+  })
+
+  operations.forEach(function (method) {
+    shimmer.wrap(levelup, method, function (fn) {
+      return function (key) {
+        var args = argsToArray(arguments)
+        var callback = args.pop()
+        var run = fn.bind.apply(fn, [this].concat(args))
+
+        var layer
+        tv.instrument(function (last) {
+          layer = last.descend('levelup', {
+            KVOp: method,
+            KVKey: key,
+          })
+          return layer
+        }, function (callback) {
+          run(method !== 'get' ? callback : function (err, res) {
+            layer.events.exit.KVHit = typeof res !== 'undefined'
+            callback(err, res)
+          })
+        }, conf, callback)
+      }
+    })
+  })
+}
+
+function patchBatch (levelup, Batch) {
+  shimmer.wrap(levelup, 'batch', function (fn) {
+    return function () {
+      var args = argsToArray(arguments)
+      if ( ! args.length) {
+        return new Batch(this, this._codec)
+      }
+
+      var callback = args.pop()
+      var run = fn.bind.apply(fn, [this].concat(args))
+
+      return tv.instrument(function (last) {
+        // Build op and key lists
+        var ops = JSON.stringify(args[0].map(getOp))
+        var keys = JSON.stringify(args[0].map(getKey))
+
+        return last.descend('levelup', {
+          KVOp: 'batch',
+          KVKeys: keys,
+          KVOps: ops,
+        })
+      }, function (callback) {
+        run(callback)
+      }, conf, callback)
+    }
+  })
+
+  shimmer.wrap(Batch.prototype, 'write', function (fn) {
+    return function () {
+      var args = argsToArray(arguments)
+      var callback = args.pop()
+      var run = fn.bind.apply(fn, [this].concat(args))
+      var self = this
+
+      return tv.instrument(function (last) {
+        // Build op and key lists
+        var ops = JSON.stringify(self.ops.map(getOp))
+        var keys = JSON.stringify(self.ops.map(getKey))
+
+        return last.descend('levelup', {
+          KVOp: 'batch',
+          KVKeys: keys,
+          KVOps: ops,
+        })
+      }, function (callback) {
+        run(callback)
+      }, conf, callback)
+    }
+  })
+}
+
+function getOp (op) {
+  return op.type
+}
+
+function getKey (op) {
+  return op.key
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "express": "~4.9.3",
     "hapi": "~7.5.2",
     "istanbul": "~0.3.2",
+    "leveldown": "~1.0.0",
+    "levelup": "~0.19.0",
     "memcached": "~2.0.0",
     "mocha": "~1.21.4",
     "mongodb": "~1.4.8",

--- a/test/probes.levelup.js
+++ b/test/probes.levelup.js
@@ -1,0 +1,134 @@
+var debug = require('debug')('probes-levelup')
+var helper = require('./helper')
+var should = require('should')
+var tv = require('..')
+var addon = tv.addon
+
+var request = require('request')
+var http = require('http')
+
+// NOTE: requiring leveldown is necessary as the one that works with
+// node 0.11 does not match the one in the devDependencies of levelup.
+var level = require('levelup')
+var db = level('./test-db', {
+  db: require('leveldown')
+})
+
+describe('probes.levelup', function () {
+  var ctx = { levelup: db }
+  var emitter
+
+  //
+  // Intercept tracelyzer messages for analysis
+  //
+  before(function (done) {
+    emitter = helper.tracelyzer(done)
+    tv.sampleRate = tv.addon.MAX_SAMPLE_RATE
+    tv.traceMode = 'always'
+  })
+  after(function (done) {
+    emitter.close(done)
+  })
+
+  // Yes, this is really, actually needed.
+  // Sampling may actually prevent reporting,
+  // if the tests run too fast. >.<
+  beforeEach(function (done) {
+    helper.padTime(done)
+  })
+
+  var check = {
+    'levelup-entry': function (msg) {
+      msg.should.have.property('Layer', 'levelup')
+      msg.should.have.property('Label', 'entry')
+    },
+    'levelup-exit': function (msg) {
+      msg.should.have.property('Layer', 'levelup')
+      msg.should.have.property('Label', 'exit')
+    }
+  }
+
+  it('should support put', function (done) {
+    helper.httpTest(emitter, function (done) {
+      db.put('foo', 'bar', done)
+    }, [
+      function (msg) {
+        check['levelup-entry'](msg)
+        msg.should.have.property('KVOp', 'put')
+        msg.should.have.property('KVKey', 'foo')
+      },
+      function (msg) {
+        check['levelup-exit'](msg)
+      }
+    ], done)
+  })
+
+  it('should support get', function (done) {
+    helper.httpTest(emitter, function (done) {
+      db.get('foo', done)
+    }, [
+      function (msg) {
+        check['levelup-entry'](msg)
+        msg.should.have.property('KVOp', 'get')
+        msg.should.have.property('KVKey', 'foo')
+      },
+      function (msg) {
+        msg.should.have.property('KVHit')
+        check['levelup-exit'](msg)
+      }
+    ], done)
+  })
+
+  it('should support del', function (done) {
+    helper.httpTest(emitter, function (done) {
+      db.del('foo', done)
+    }, [
+      function (msg) {
+        check['levelup-entry'](msg)
+        msg.should.have.property('KVOp', 'del')
+        msg.should.have.property('KVKey', 'foo')
+      },
+      function (msg) {
+        check['levelup-exit'](msg)
+      }
+    ], done)
+  })
+
+  it('should support array batch', function (done) {
+    helper.httpTest(emitter, function (done) {
+      db.batch([
+        { type: 'put', key: 'foo', value: 'bar' },
+        { type: 'del', key: 'foo' },
+      ], done)
+    }, [
+      function (msg) {
+        check['levelup-entry'](msg)
+        msg.should.have.property('KVOp', 'batch')
+        msg.should.have.property('KVKeys', '["foo","foo"]')
+        msg.should.have.property('KVOps', '["put","del"]')
+      },
+      function (msg) {
+        check['levelup-exit'](msg)
+      }
+    ], done)
+  })
+
+  it('should support chained batch', function (done) {
+    helper.httpTest(emitter, function (done) {
+      db.batch()
+        .put('foo', 'bar')
+        .del('foo')
+        .write(done)
+    }, [
+      function (msg) {
+        check['levelup-entry'](msg)
+        msg.should.have.property('KVOp', 'batch')
+        msg.should.have.property('KVKeys', '["foo","foo"]')
+        msg.should.have.property('KVOps', '["put","del"]')
+      },
+      function (msg) {
+        check['levelup-exit'](msg)
+      }
+    ], done)
+  })
+})


### PR DESCRIPTION
This is basic instrumentation for the levelup module.

It includes experimental instrumentation for the batch command. It currently replaces KVKey with KVKeys and KVOps, which are simply arrays of strings. It can also be used as a [chainable API](https://github.com/rvagg/node-levelup#dbbatch-chained-form). The chainable mode doesn't currently work. Also, buffer values probably don't work either yet.

Does the KVKeys/KVOps approach seem reasonable?

You can also use read/write streams with levelup, which I haven't looked too deeply at yet. That looks like a more complicated thing and I'm not sure exactly how we'd want to represent it, or if we even *want* to instrument it.