### PR TITLE
Make factory function modules work correctly with multiple requires

### DIFF
--- a/lib/require-patch.js
+++ b/lib/require-patch.js
@@ -1,4 +1,5 @@
 var debug = require('debug')('traceview:require-patch')
+var Module = require('module')
 var fs = require('fs')
 
 var realRequire = module.__proto__.require
@@ -40,14 +41,23 @@ exports.enable = function () {
 
     // Only apply probes on first run
     if (module && probes.hasOwnProperty(name) && !module._patchedByTraceView) {
+      // Set relative require helper to point to the module being patched
+      exports.relativeRequire = this.require.bind(this)
+
+      // Patch
+      var path = Module._resolveFilename(name, this)
+      module = realRequire(probes[name])(module)
+
+      // Mark as patched
       Object.defineProperty(module, '_patchedByTraceView', {
         value: true
       })
 
-      // Set relative require helper to point to the module being patched
-      exports.relativeRequire = this.require.bind(this)
+      // Replace cached version
+      if (require.cache[path]) {
+        require.cache[path].exports = module
+      }
 
-      module = realRequire(probes[name])(module)
       debug('patched ' + name)
     }
 


### PR DESCRIPTION
Factory function modules are not being loaded correctly on subsequent `require()` calls. This fixes that.