### PR TITLE
[oracle] Instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - if [[ "`node --version`" =~ ^v0.8* ]]; then npm -g install npm; fi
   - npm install
   - npm install leveldown
+  - npm run install-deps || true
 
 script: "npm test"
 

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+{
+  npm install oracledb@0.3.1
+} || {
+  exit 0
+}

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -120,6 +120,14 @@ module.exports = {
     sanitizeSql: false
   },
 
+  // https://npmjs.org/package/oracledb
+  oracledb: {
+    enabled: true,
+    collectBacktraces: true,
+    sanitizeSql: false
+  },
+
+  // https://npmjs.org/package/raw-body
   'raw-body': {
     enabled: true,
     collectBacktraces: true

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -13,8 +13,10 @@ module.exports = function (oracledb) {
 function patchProto (proto, oracledb) {
   patchGetConnection(proto, oracledb)
 
+  if (proto.createPool.__tv_patched) return
+
   shimmer.wrap(proto, 'createPool', function (fn) {
-    return function () {
+    function createPool () {
       var args = argsToArray(arguments)
       var cb = args.pop()
 
@@ -32,12 +34,18 @@ function patchProto (proto, oracledb) {
 
       return fn.apply(this, args)
     }
+
+    createPool.__tv_patched = true
+
+    return createPool
   })
 }
 
 function patchGetConnection (proto, oracledb, options) {
+  if (proto.getConnection.__tv_patched) return
+
   shimmer.wrap(proto, 'getConnection', function (fn) {
-    return function () {
+    function getConnection () {
       var args = argsToArray(arguments)
       var cb = args.pop()
 
@@ -55,6 +63,10 @@ function patchGetConnection (proto, oracledb, options) {
 
       return fn.apply(this, args)
     }
+
+    getConnection.__tv_patched = true
+
+    return getConnection
   })
 }
 
@@ -67,8 +79,10 @@ function patchConnection (conn, oracledb, options) {
   ]
 
   methods.forEach(function (method) {
+    if (conn[method].__tv_patched) return
+
     shimmer.wrap(conn, method, function (fn) {
-      return function (query, queryArgs) {
+      function wrapped (query, queryArgs) {
         var args = argsToArray(arguments)
         var cb = args.pop()
         var self = this
@@ -120,12 +134,18 @@ function patchConnection (conn, oracledb, options) {
           return fn.apply(self, args.concat(done))
         }, conf, cb)
       }
+
+      wrapped.__tv_patched = true
+
+      return wrapped
     })
   })
 
+  if (conn.release.__tv_patched) return
+
   // Patch release method to keep continuation
   shimmer.wrap(conn, 'release', function (fn) {
-    return function (cb) {
+    function release (cb) {
       // Retain continuation, if we are in one
       if (Layer.last) {
         cb = tv.requestStore.bind(cb)
@@ -133,6 +153,10 @@ function patchConnection (conn, oracledb, options) {
 
       return fn.call(this, cb)
     }
+
+    release.__tv_patched = true
+
+    return release
   })
 }
 

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -1,0 +1,159 @@
+var argsToArray = require('sliced')
+var shimmer = require('shimmer')
+var Layer = require('../layer')
+var tv = require('..')
+var conf = tv.oracledb
+var Sanitizer = tv.addon.Sanitizer
+
+module.exports = function (oracledb) {
+  patchProto(oracledb.__proto__, oracledb)
+  return oracledb
+}
+
+function patchProto (proto, oracledb) {
+  patchGetConnection(proto, oracledb)
+
+  shimmer.wrap(proto, 'createPool', function (fn) {
+    return function () {
+      var args = argsToArray(arguments)
+      var cb = args.pop()
+
+      // Retain continuation, if we are in one
+      if (Layer.last) {
+        cb = tv.requestStore.bind(cb)
+      }
+
+      // Wrap callback so we can patch the connection
+      args.push(function (err, pool) {
+        if (err) return cb(err)
+        patchGetConnection(pool.__proto__, oracledb, args[0])
+        return cb(null, pool)
+      })
+
+      return fn.apply(this, args)
+    }
+  })
+}
+
+function patchGetConnection (proto, oracledb, options) {
+  shimmer.wrap(proto, 'getConnection', function (fn) {
+    return function () {
+      var args = argsToArray(arguments)
+      var cb = args.pop()
+
+      // Retain continuation, if we are in one
+      if (Layer.last) {
+        cb = tv.requestStore.bind(cb)
+      }
+
+      // Wrap callback so we can patch the connection
+      args.push(function (err, conn) {
+        if (err) return cb(err)
+        patchConnection(conn.__proto__, oracledb, options || args[0])
+        return cb(null, conn)
+      })
+
+      return fn.apply(this, args)
+    }
+  })
+}
+
+function patchConnection (conn, oracledb, options) {
+  var methods = [
+    'execute',
+    'commit',
+    'rollback',
+    'break'
+  ]
+
+  methods.forEach(function (method) {
+    shimmer.wrap(conn, method, function (fn) {
+      return function (query, queryArgs) {
+        var args = argsToArray(arguments)
+        var cb = args.pop()
+        var self = this
+        var layer
+
+        return tv.instrument(function (last) {
+          // Parse host and database from connectString
+          var parts = options.connectString.split('/')
+          var database = parts.pop()
+          var host = parts.pop()
+
+          // Build k/v pair object
+          var data = {
+            RemoteHost: host,
+            Database: database,
+            Flavor: 'oracle',
+
+            // Report auto-commit status of each query
+            isAutoCommit: isAutoCommit(oracledb, args)
+          }
+
+          // Methods other than execute have implicit query names
+          if (typeof query !== 'string') {
+            query = method.toUpperCase()
+          } else {
+            // Sanitize queries, when configured to do so
+            if (conf.sanitizeSql) {
+              query = sanitize(query)
+
+            // Only include QueryArgs when not sanitizing
+            } else if (isArgs(queryArgs)) {
+              data.QueryArgs = JSON.stringify(queryArgs)
+            }
+
+            // Trim long queries
+            if (query.length > 1024) {
+              data.QueryTruncated = true
+              query = trim(1024)(query)
+            }
+          }
+
+          // Add query
+          data.Query = query
+
+          layer = last.descend('oracle', data)
+
+          return layer
+        }, function (done) {
+          return fn.apply(self, args.concat(done))
+        }, conf, cb)
+      }
+    })
+  })
+
+  // Patch release method to keep continuation
+  shimmer.wrap(conn, 'release', function (fn) {
+    return function (cb) {
+      // Retain continuation, if we are in one
+      if (Layer.last) {
+        cb = tv.requestStore.bind(cb)
+      }
+
+      return fn.call(this, cb)
+    }
+  })
+}
+
+// Trim a value, if it exceeds the specified length,
+// and ensure buffers are converted to strings.
+function trim (n) {
+  return function (v) {
+    return v ? (v.length > n ? v.slice(0, n) : v).toString() : null
+  }
+}
+
+function sanitize (query) {
+  return Sanitizer.sanitize(query, Sanitizer.OBOE_SQLSANITIZE_KEEPDOUBLE)
+}
+
+function isArgs (v) {
+  return Array.isArray(v) || typeof v == 'object'
+}
+
+function isAutoCommit (oracledb, args) {
+  return (args.length > 2  && typeof args[2].isAutoCommit !== 'undefined')
+    ? args[2].isAutoCommit
+    : oracledb.isAutoCommit
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha",
     "docs": "yuidoc .",
     "install": "./build.sh",
+    "install-deps": "./deps.sh",
     "coverage": "npm run coverage:report",
     "coverage:build": "rm -rf coverage && istanbul cover _mocha",
     "coverage:report": "npm run coverage:build && istanbul report",

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -59,20 +59,100 @@ describe('probes.oracledb', function () {
 
   if (oracledb && host && database && config.user && config.password) {
     it('should trace execute calls', test_basic)
+    it('should trace execute calls in pool', test_pool)
+    it('should include correct isAutoCommit value', test_commit)
   } else {
     it.skip('should trace execute calls', test_basic)
+    it.skip('should trace execute calls in pool', test_pool)
+    it.skip('should include correct isAutoCommit value', test_commit)
   }
 
   function test_basic (done) {
     helper.httpTest(emitter, function (done) {
-      oracledb.getConnection(config, function (err, connection) {
+      function query (err, connection) {
         if (err) return done(err)
         connection.execute('SELECT 1 FROM DUAL', done)
+      }
+
+      oracledb.getConnection(config, query)
+    }, [
+      function (msg) {
+        checks['oracle-entry'](msg)
+        msg.should.have.property('Query', 'SELECT 1 FROM DUAL')
+      },
+      function (msg) {
+        checks['oracle-exit'](msg)
+      }
+    ], done)
+  }
+
+  function test_pool (done) {
+    helper.httpTest(emitter, function (done) {
+      function query (err, connection) {
+        if (err) return done(err)
+        connection.execute('SELECT 1 FROM DUAL', done)
+      }
+
+      oracledb.createPool(config, function (err, pool) {
+        if (err) return done(err)
+        pool.getConnection(query)
       })
     }, [
       function (msg) {
         checks['oracle-entry'](msg)
         msg.should.have.property('Query', 'SELECT 1 FROM DUAL')
+      },
+      function (msg) {
+        checks['oracle-exit'](msg)
+      }
+    ], done)
+  }
+
+  function test_commit (done) {
+    helper.httpTest(emitter, function (done) {
+      oracledb.isAutoCommit = false
+      oracledb.getConnection(config, function (err, connection) {
+        function query (isAutoCommit, done) {
+          var options = {
+            isAutoCommit: isAutoCommit
+          }
+
+          return function (err) {
+            if (err) return done(err)
+            connection.execute('SELECT 1 FROM DUAL', [], options, done)
+          }
+        }
+
+        var fn = query(
+          undefined,
+          query(
+            true,
+            query(
+              false,
+              done
+            )
+          )
+        )
+        fn()
+      })
+    }, [
+      function (msg) {
+        checks['oracle-entry'](msg)
+        msg.should.have.property('isAutoCommit', false)
+      },
+      function (msg) {
+        checks['oracle-exit'](msg)
+      },
+      function (msg) {
+        checks['oracle-entry'](msg)
+        msg.should.have.property('isAutoCommit', true)
+      },
+      function (msg) {
+        checks['oracle-exit'](msg)
+      },
+      function (msg) {
+        checks['oracle-entry'](msg)
+        msg.should.have.property('isAutoCommit', false)
       },
       function (msg) {
         checks['oracle-exit'](msg)

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -1,0 +1,83 @@
+var tv = require('../..')
+var addon = tv.addon
+
+var helper = require('../helper')
+var should = require('should')
+
+var oracledb
+try {
+  oracledb = require('oracledb')
+} catch (e) {}
+
+var host = process.env.ORACLE_HOST
+var database = process.env.ORACLE_DATABASE
+var config = {
+  connectString: host + '/' + database,
+  password: process.env.ORACLE_PASS,
+  user: process.env.ORACLE_USER
+}
+
+describe('probes.oracledb', function () {
+  var emitter
+  var ctx = {}
+  var cluster
+  var pool
+  var db
+
+  //
+  // Intercept tracelyzer messages for analysis
+  //
+  before(function (done) {
+    emitter = helper.tracelyzer(done)
+    tv.sampleRate = tv.addon.MAX_SAMPLE_RATE
+    tv.traceMode = 'always'
+  })
+  after(function (done) {
+    emitter.close(done)
+  })
+
+  // Yes, this is really, actually needed.
+  // Sampling may actually prevent reporting,
+  // if the tests run too fast. >.<
+  beforeEach(function (done) {
+    helper.padTime(done)
+  })
+
+  var checks = {
+    'oracle-entry': function (msg) {
+      msg.should.have.property('Layer', 'oracle')
+      msg.should.have.property('Label', 'entry')
+      msg.should.have.property('Database', database)
+      msg.should.have.property('Flavor', 'oracle')
+      msg.should.have.property('RemoteHost', host)
+    },
+    'oracle-exit': function (msg) {
+      msg.should.have.property('Layer', 'oracle')
+      msg.should.have.property('Label', 'exit')
+    }
+  }
+
+  if (oracledb && host && database && config.user && config.password) {
+    it('should trace execute calls', test_basic)
+  } else {
+    it.skip('should trace execute calls', test_basic)
+  }
+
+  function test_basic (done) {
+    helper.httpTest(emitter, function (done) {
+      oracledb.getConnection(config, function (err, connection) {
+        if (err) return done(err)
+        connection.execute('SELECT 1 FROM DUAL', done)
+      })
+    }, [
+      function (msg) {
+        checks['oracle-entry'](msg)
+        msg.should.have.property('Query', 'SELECT 1 FROM DUAL')
+      },
+      function (msg) {
+        checks['oracle-exit'](msg)
+      }
+    ], done)
+  }
+
+})


### PR DESCRIPTION
Here's some basic instrumentation for the new, official Oracle DB driver. The module itself only builds on a few specific versions of node 0.10.x currently, so it's installed separately from other dev dependencies to allow TravisCI to ignore when it fails to install and just skip the tests for that node release.

Also, we'll need to figure out what to do about testing it on TravisCI, as they don't have Oracle support built-in. Like MSSQL, we'll need a separate testing database.