### PR TITLE
[http] Prevent http(s) clients from crossing streams and awakening zalgo

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -68,31 +68,34 @@ function patchClient (module, proto) {
         data.Backtrace = tv.backtrace()
       }
 
-      layer.enter(data)
+      var ret
+      tv.requestStore.run(function () {
+        layer.enter(data)
 
-      // Do request
-      var ret = fn(options, callback)
+        // Do request
+        ret = fn(options, callback)
 
-      // Ensure the event list for the response event is an array
-      if ( ! ret._events.response) {
-        ret._events.response = []
-      } else if ( ! Array.isArray(ret._events.response)) {
-        ret._events.response = [ret._events.response]
-      }
-
-      // Ensure our exit is pushed to the FRONT of the event list
-      ret._events.response.unshift(tv.requestStore.bind(function (res) {
-        // Continue from X-Trace header, if present
-        var xtrace = res.headers['x-trace']
-        if (xtrace) {
-          layer.events.exit.edges.push(xtrace)
+        // Ensure the event list for the response event is an array
+        if ( ! ret._events.response) {
+          ret._events.response = []
+        } else if ( ! Array.isArray(ret._events.response)) {
+          ret._events.response = [ret._events.response]
         }
 
-        // Send exit event with response status
-        layer.exit({
-          HTTPStatus: res.statusCode
-        })
-      }))
+        // Ensure our exit is pushed to the FRONT of the event list
+        ret._events.response.unshift(tv.requestStore.bind(function (res) {
+          // Continue from X-Trace header, if present
+          var xtrace = res.headers['x-trace']
+          if (xtrace) {
+            layer.events.exit.edges.push(xtrace)
+          }
+
+          // Send exit event with response status
+          layer.exit({
+            HTTPStatus: res.statusCode
+          })
+        }))
+      })
 
       return ret
     }


### PR DESCRIPTION
HTTP client requests need their own run scope so they don't step on each other.