### PR TITLE
[cassandra-driver] Fix tests for recent module versions

### DIFF
--- a/test/probes/cassandra-driver/prepare.js
+++ b/test/probes/cassandra-driver/prepare.js
@@ -1,3 +1,3 @@
 exports.run = function (ctx, done) {
-  ctx.cassandra.execute('SELECT now() FROM system.local', { prepare: true }, done)
+  ctx.cassandra.execute('SELECT now() FROM system.local', null, { prepare: true }, done)
 }

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,7 +1,7 @@
 var semver = require('semver')
 var modules = module.exports = []
 
-test('cassandra-driver',    '>= 0.2.0 < 2.0.0')
+test('cassandra-driver',    '>= 0.2.0')
 test('co-render',           '*',                'gulp test:probe:koa')
 test('express',             '>= 3.0.0')
 test('hapi',                '>= 6.0.0')


### PR DESCRIPTION
Seems recent versions of cassandra-driver are a little less forgiving of params/options argument positions.