### PR TITLE
[mysql] Fix wrong-context issue

### DIFF
--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -49,7 +49,7 @@ function patchQuery (fn, Query) {
     // If there is no continuation, just run normally
     var last = Layer.last
     if ( ! last) {
-      return fn.apply(self, arguments)
+      return fn.apply(this, arguments)
     }
 
     // Convert args to an array


### PR DESCRIPTION
This fixes `Object #<Object> has no method '_implyConnect'` errors.