### PR TITLE
[misc] Fail gracefully when searching for node_modules folder

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -388,13 +388,19 @@ process.nextTick(function () {
     }
 
     var base = path.join(process.cwd(), 'node_modules')
-    fs.readdirSync(base).forEach(function (mod) {
-      if (mod === '.bin' || mod[0] === '@') return
-      try {
-        var pkg = require(base + '/' + mod + '/package.json')
-        data['Node.Module.' + pkg.name + '.Version'] = pkg.version
-      } catch (e) {}
-    })
+    var modules
+    try { modules = fs.readdirSync(base) }
+    catch (e) {}
+
+    if (Array.isArray(modules)) {
+      modules.forEach(function (mod) {
+        if (mod === '.bin' || mod[0] === '@') return
+        try {
+          var pkg = require(base + '/' + mod + '/package.json')
+          data['Node.Module.' + pkg.name + '.Version'] = pkg.version
+        } catch (e) {}
+      })
+    }
 
     var layer = new Layer('nodejs', null, data)
     layer.enter()


### PR DESCRIPTION
This prevents an error when searching for module versions while the working directory is not the app root.