### PR TITLE
[test] Use docker link env variables for db hosts, where available

### DIFF
--- a/test/error.test.js
+++ b/test/error.test.js
@@ -9,7 +9,8 @@ var request = require('request')
 var http = require('http')
 
 var redis = require('redis')
-var client = redis.createClient()
+var db_host = process.env.REDIS_PORT_6379_TCP_ADDR || 'localhost'
+var client = redis.createClient(6379, db_host, {})
 
 describe('error', function () {
   var emitter

--- a/test/probes/amqp.test.js
+++ b/test/probes/amqp.test.js
@@ -4,6 +4,7 @@ var addon = tv.addon
 
 var should = require('should')
 var amqp = require('amqp')
+var db_host = process.env.RABBITMQ_PORT_5672_TCP_ADDR || 'localhost'
 
 describe('probes.amqp', function () {
   var emitter
@@ -49,7 +50,7 @@ describe('probes.amqp', function () {
   //
   before(function (done) {
     client = amqp.createConnection({
-      host: 'localhost'
+      host: db_host
     }, {
       reconnect: false
     })

--- a/test/probes/cassandra-driver.test.js
+++ b/test/probes/cassandra-driver.test.js
@@ -3,6 +3,8 @@ var tv = helper.tv
 var addon = tv.addon
 
 var should = require('should')
+var db_host = process.env.CASSANDRA_PORT_9160_TCP_ADDR || '127.0.0.1'
+var remote_host = db_host + ':9042'
 
 //
 // Do not load unless stream.Readable exists.
@@ -34,7 +36,7 @@ describe('probes.cassandra-driver', function () {
     info: function (msg) {
       msg.should.have.property('Layer', 'cassandra')
       msg.should.have.property('Label', 'info')
-      msg.should.have.property('RemoteHost', '127.0.0.1:9042')
+      msg.should.have.property('RemoteHost', remote_host)
     },
     exit: function (msg) {
       msg.should.have.property('Layer', 'cassandra')
@@ -70,7 +72,7 @@ describe('probes.cassandra-driver', function () {
     //
     before(function () {
       client = ctx.cassandra = new cassandra.Client({
-        contactPoints: ['127.0.0.1'],
+        contactPoints: [db_host],
         keyspace: 'test'
       })
     })

--- a/test/probes/memcached.test.js
+++ b/test/probes/memcached.test.js
@@ -7,6 +7,7 @@ var semver = require('semver')
 
 var Memcached = require('memcached')
 var pkg = require('memcached/package.json')
+var db_host = process.env.MEMCACHED_PORT_11211_TCP_ADDR || '127.0.0.1'
 
 describe('probes.memcached', function () {
   var emitter
@@ -29,7 +30,7 @@ describe('probes.memcached', function () {
   // Create client instance
   //
   before(function () {
-    mem = new Memcached('127.0.0.1:11211')
+    mem = new Memcached(db_host + ':11211')
   })
 
   //

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -13,6 +13,7 @@ var requirePatch = require('../../lib/require-patch')
 requirePatch.disable()
 var pkg = require('mongodb/package.json')
 requirePatch.enable()
+var db_host = process.env.MONGODB_PORT_27017_TCP_ADDR || 'localhost'
 
 describe('probes.mongodb', function () {
 	var ctx = {}
@@ -42,7 +43,7 @@ describe('probes.mongodb', function () {
 	// Open a fresh mongodb connection for each test
 	//
 	before(function (done) {
-		MongoDB.connect('mongodb://localhost/test', function (err, _db) {
+		MongoDB.connect('mongodb://' + db_host + '/test', function (err, _db) {
 			if (err) return done(err)
 			ctx.mongo = db = _db
 			done()

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -10,6 +10,7 @@ var http = require('http')
 
 var pkg = require('mysql/package.json')
 var mysql = require('mysql')
+var db_host = process.env.MYSQL_PORT_3306_TCP_ADDR || 'localhost'
 
 describe('probes.mysql', function () {
   var emitter
@@ -43,7 +44,7 @@ describe('probes.mysql', function () {
       msg.should.have.property('Label', 'entry')
       msg.should.have.property('Database', 'test')
       msg.should.have.property('Flavor', 'mysql')
-      msg.should.have.property('RemoteHost', 'localhost:3306')
+      msg.should.have.property('RemoteHost', db_host + ':3306')
     },
     exit: function (msg) {
       msg.should.have.property('Layer', 'mysql')
@@ -54,7 +55,7 @@ describe('probes.mysql', function () {
   if (semver.satisfies(pkg.version, '>= 2.0.0')) {
     beforeEach(function (done) {
       db = ctx.mysql = mysql.createConnection({
-        host: 'localhost',
+        host: db_host,
         database: 'test',
         user: 'root'
       })
@@ -62,7 +63,7 @@ describe('probes.mysql', function () {
       // Set pool and pool cluster
       var poolConfig = {
         connectionLimit: 10,
-        host: 'localhost',
+        host: db_host,
         database: 'test',
         user: 'root'
       }
@@ -80,7 +81,7 @@ describe('probes.mysql', function () {
   } else if (semver.satisfies(pkg.version, '>= 0.9.2')) {
     beforeEach(function () {
       db = ctx.mysql = mysql.createClient({
-        host: 'localhost',
+        host: db_host,
         database: 'test',
         user: 'root'
       })
@@ -88,7 +89,7 @@ describe('probes.mysql', function () {
   } else {
     beforeEach(function (done) {
       db = ctx.mysql = new mysql.Client({
-        host: 'localhost',
+        host: db_host,
         database: 'test',
         user: 'root'
       })

--- a/test/probes/node-cassandra-cql.test.js
+++ b/test/probes/node-cassandra-cql.test.js
@@ -3,6 +3,7 @@ var tv = helper.tv
 var addon = tv.addon
 
 var should = require('should')
+var db_host = process.env.CASSANDRA_PORT_9042_TCP_ADDR || 'localhost'
 
 //
 // Do not load unless stream.Readable exists.
@@ -34,7 +35,7 @@ describe('probes.cassandra', function () {
     info: function (msg) {
       msg.should.have.property('Layer', 'cassandra')
       msg.should.have.property('Label', 'info')
-      msg.should.have.property('RemoteHost', 'localhost:9042')
+      msg.should.have.property('RemoteHost', db_host + ':9042')
     },
     exit: function (msg) {
       msg.should.have.property('Layer', 'cassandra')
@@ -70,7 +71,7 @@ describe('probes.cassandra', function () {
     //
     before(function (done) {
       client = new cql.Client({
-        hosts: ['localhost'],
+        hosts: [db_host],
         keyspace: 'test'
       })
       ctx.cql = client

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -8,7 +8,8 @@ var request = require('request')
 var http = require('http')
 
 var postgres = require('pg')
-var conString = 'postgres://postgres@localhost/test'
+var db_host = process.env.POSTGRES_PORT_5432_TCP_ADDR || 'localhost'
+var conString = 'postgres://postgres@' + db_host + '/test'
 
 var stream = require('stream')
 var canNative = typeof stream.Duplex !== 'undefined'
@@ -81,7 +82,7 @@ describe('probes.postgres', function () {
         msg.should.have.property('Label', 'entry')
         msg.should.have.property('Database', 'test')
         msg.should.have.property('Flavor', 'postgresql')
-        msg.should.have.property('RemoteHost', 'localhost:5432')
+        msg.should.have.property('RemoteHost', db_host + ':5432')
       },
       exit: function (msg) {
         msg.should.have.property('Layer', 'postgres')

--- a/test/probes/redis.test.js
+++ b/test/probes/redis.test.js
@@ -8,7 +8,8 @@ var request = require('request')
 var http = require('http')
 
 var redis = require('redis')
-var client = redis.createClient()
+var db_host = process.env.REDIS_PORT_6379_TCP_ADDR || 'localhost'
+var client = redis.createClient(6379, db_host, {})
 
 describe('probes.redis', function () {
   var ctx = { redis: client }

--- a/test/probes/redis/pubsub.js
+++ b/test/probes/redis/pubsub.js
@@ -1,7 +1,8 @@
 var redis = require('redis')
 
 exports.run = function (ctx, done) {
-  var producer = redis.createClient()
+  var db_host = process.env.REDIS_PORT_6379_TCP_ADDR || 'localhost'
+  var producer = redis.createClient(6379, db_host, {})
 
   ctx.redis.on('subscribe', function () {
     producer.publish('foo', 'bar')


### PR DESCRIPTION
This PR changes the tests to use docker link env variables for db hosts, where available. This makes testing in a network of docker containers easier.