### PR TITLE
[tedious] Fix tedious support for io.js 2.x

### DIFF
--- a/lib/probes/tedious.js
+++ b/lib/probes/tedious.js
@@ -13,6 +13,15 @@ module.exports = function (tedious) {
 }
 
 function patchConnection (connection) {
+  shimmer.wrap(connection, 'defaultConfig', function (def) {
+    return function () {
+      if (Layer.last) {
+        tv.requestStore.bindEmitter(this)
+      }
+      return def.apply(this, arguments)
+    }
+  })
+
   shimmer.wrap(connection, 'makeRequest', function (fn) {
     return function (request, packetType, payload) {
       var args = argsToArray(arguments)


### PR DESCRIPTION
This binds the connection emitter to the request context at creation time.