### PR TITLE
[test] Fix mongodb tests to work with 2.x

### DIFF
--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -107,7 +107,7 @@ describe('probes.mongodb', function () {
 			]
 
 			// The db.command used in collection.count called cursor.nextObject
-			if (semver.satisfies(pkg.version, '<1.4.11 || >=1.4.24')) {
+			if (semver.satisfies(pkg.version, '<1.4.11 || >1.4.23 <2.0.0')) {
 				steps.push(function () {})
 				steps.push(function () {})
 			}
@@ -132,7 +132,7 @@ describe('probes.mongodb', function () {
 				}
 			]
 
-			if (semver.satisfies(pkg.version, '< 1.4.13 || >=1.4.24')) {
+			if (semver.satisfies(pkg.version, '<1.4.13 || >1.4.23 <2.0.0')) {
 				steps.push(function () {})
 				steps.push(function () {})
 			}
@@ -381,7 +381,7 @@ describe('probes.mongodb', function () {
 				}
 			]
 
-			if (semver.satisfies(pkg.version, '<1.4.11 || >=1.4.24')) {
+			if (semver.satisfies(pkg.version, '<1.4.11 || >1.4.23 <2.0.0')) {
 				steps.push(function (msg) {})
 				steps.push(function (msg) {})
 			}
@@ -422,7 +422,7 @@ describe('probes.mongodb', function () {
 				}
 			]
 
-			if (semver.satisfies(pkg.version, '<1.4.11 || >=1.4.24')) {
+			if (semver.satisfies(pkg.version, '<1.4.11 || >1.4.23 <2.0.0')) {
 				steps.push(function () {})
 				steps.push(function () {})
 			}

--- a/test/versions.js
+++ b/test/versions.js
@@ -18,11 +18,11 @@ test('memcached', version('>= 0.12.0') ? [
                             '>= 0.1.1'
 ])
 
-// Exclude 1.4.13 - 1.4.16 due to bugs
+// NOTE: Versions from mid 1.4.x to early 2.x are excluded due to mongodb bugs
 test('mongodb', [
-                            '1.2.9 - 1.4.12 || >= 1.4.17 <2.0.0',
-                            // TODO: Fix recent mongo versions
-                            // '>= 2.0.8'
+                            '1.2.9 - 1.4.12',
+                            '>= 1.4.17 <2.0.0',
+                            '>= 2.0.9'
 ])
 test('mysql',               '> 0.9.0')
 test('node-cassandra-cql',  '>= 0.2.0')


### PR DESCRIPTION
The tests were not compatible with the 2.x range of mongodb. This fixes that.