### PR TITLE
[express] Prevent route profiles throwing errors after lost context

### DIFF
--- a/lib/probes/express.js
+++ b/lib/probes/express.js
@@ -29,7 +29,8 @@ function routeProfiling (express, version) {
     return function (req, res, next) {
       // Check if we've stored an http layer to hook into
       var httpLayer = res._http_layer
-      if ( ! httpLayer) {
+      var last = Layer.last
+      if ( ! httpLayer || ! last) {
         return func.apply(this, arguments)
       }
 
@@ -45,7 +46,7 @@ function routeProfiling (express, version) {
 
       // Create profile for this route function
       var args = argsToArray(arguments)
-      var layer = Layer.last.profile(controller + ' ' + action, {
+      var layer = last.profile(controller + ' ' + action, {
         Controller: controller,
         Action: action
       })


### PR DESCRIPTION
This prevents `TypeError - Cannot call method 'profile' of undefined`, which occurs when wrapping a route in a profile after the request context has been lost.