### PR TITLE
[test] Add emitter setting to forward messages to real tracelyzer

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 var tv = exports.tv = require('..')
+var realPort = tv.port
 tv.skipSample = true
 
 var debug = require('debug')('traceview:test:helper')
@@ -25,6 +26,10 @@ exports.tracelyzer = function (done) {
     var parsed = BSON.deserialize(msg)
     log('mock tracelyzer (port ' + port + ') received', parsed)
     emitter.emit('message', parsed)
+
+    if (emitter.forward) {
+      server.send(msg, 0, msg.length, Number(realPort), 'localhost', function () {})
+    }
   })
 
   // Wait for the server to become available


### PR DESCRIPTION
This makes it easier to generate test traces to send to the real tracelyzer. Just set `emitter.forward = true` and all messages passed through the mock tracelyzer will also get forwarded to the real tracelyzer.