### PR TITLE
[mysql] Report caller errors

### DIFF
--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -55,6 +55,7 @@ function patchQuery (fn, Query) {
     // Convert args to an array
     var args = argsToArray(arguments)
     var self = this
+    var layer
 
     // There are several different ways to call query(),
     // with a callback, with a Query constructor which
@@ -62,30 +63,35 @@ function patchQuery (fn, Query) {
     //
     // This normalizes all these patterns into one runner.
     function runner (wrap) {
-      // Callback-style
-      if (typeof args[args.length - 1] === 'function') {
-        args.push(wrap(args.pop()))
-        return fn.apply(self, args)
-      }
-
-      // Constructor-style
-      if (sql instanceof Query && args[0]._callback) {
-        args[0]._callback = wrap(args[0]._callback)
-        return fn.apply(self, args)
-      }
-
-      // Event-style
-      var ret = fn.apply(self, args)
-      shimmer.wrap(ret, 'emit', function (emit) {
-        return function (ev, val) {
-          switch (ev) {
-            case 'error': wrap(noop)(val); break
-            case 'end': wrap(noop)(); break
-          }
-          return emit.apply(this, arguments)
+      try {
+        // Callback-style
+        if (typeof args[args.length - 1] === 'function') {
+          args.push(wrap(args.pop()))
+          return fn.apply(self, args)
         }
-      })
-      return ret
+
+        // Constructor-style
+        if (sql instanceof Query && args[0]._callback) {
+          args[0]._callback = wrap(args[0]._callback)
+          return fn.apply(self, args)
+        }
+
+        // Event-style
+        var ret = fn.apply(self, args)
+        shimmer.wrap(ret, 'emit', function (emit) {
+          return function (ev, val) {
+            switch (ev) {
+              case 'error': wrap(noop)(val); break
+              case 'end': wrap(noop)(); break
+            }
+            return emit.apply(this, arguments)
+          }
+        })
+        return ret
+      } catch (err) {
+        layer.info({ error: err })
+        throw err
+      }
     }
 
     // If mysql instrumentation is off, just bind to request continuation
@@ -126,7 +132,9 @@ function patchQuery (fn, Query) {
       if (Array.isArray(data.QueryArgs)) {
         // Trim large values and ensure buffers are converted to strings
         data.QueryArgs = data.QueryArgs.map(function (arg) {
-          return (arg.length > 1000 ? arg.slice(0, 1000) : arg).toString()
+          if (Buffer.isBuffer(arg) || typeof arg === 'string') {
+            return (arg.length > 1000 ? arg.slice(0, 1000) : arg).toString()
+          }
         })
       }
       data.QueryArgs = JSON.stringify(data.QueryArgs)
@@ -144,7 +152,8 @@ function patchQuery (fn, Query) {
     }
 
     // Run mysql action in layer container
-    return last.descend('mysql', data).run(runner)
+    layer = last.descend('mysql', data)
+    return layer.run(runner)
   }
 }
 


### PR DESCRIPTION
This prevents erroneous arguments failing within the instrumentation, and reports errors thrown by mysql itself as an info event.