### PR TITLE
[http] URL query filtering

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -45,14 +45,24 @@ module.exports = {
     collectBacktraces: true
   },
 
+  http: {
+    includeRemoteUrlParams: true
+  },
+
+  https: {
+    includeRemoteUrlParams: true
+  },
+
   'http-client': {
     enabled: true,
-    collectBacktraces: true
+    collectBacktraces: true,
+    includeRemoteUrlParams: true
   },
 
   'https-client': {
     enabled: true,
-    collectBacktraces: true
+    collectBacktraces: true,
+    includeRemoteUrlParams: true
   },
 
   fs: {

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -3,7 +3,6 @@ var shimmer = require('shimmer')
 var url = require('url')
 var os = require('os')
 
-var requirePatch = require('../require-patch')
 var Layer = require('../layer')
 var Event = require('../event')
 var tv = require('..')
@@ -29,7 +28,7 @@ function patchClient (module, proto) {
       }
 
       // If disabled or a call from https.request, just bind
-      if ( ! conf.enabled || (proto == 'http' && options._defaultAgent)) {
+      if ( ! conf.enabled || (proto === 'http' && options._defaultAgent)) {
         return fn(options, callback ? tv.requestStore.bind(callback) : undefined)
       }
 
@@ -40,27 +39,31 @@ function patchClient (module, proto) {
       // Parse options object
       if (typeof options === 'string') {
         options = url.parse(options)
-      } else {
-        options = extend({}, options)
       }
+      var parsed = extend({}, options)
 
       // Add X-Trace header to trace hops
       options.headers = options.headers || {}
       options.headers['X-Trace'] = layer.events.entry.toString()
 
       // Set default protocol
-      options.protocol = options.protocol || proto + ':'
+      parsed.protocol = parsed.protocol || proto + ':'
 
-      // Support host or hostname + port
-      if ( ! options.host && options.hostname) {
-        options.host = options.hostname
-        if (options.port) options.host += ':' + options.port
+      // Fix wrong options structure for formatting url
+      var i = parsed.path.indexOf('?')
+      parsed.pathname = parsed.path.slice(0, i)
+      parsed.search = parsed.path.slice(i)
+
+      // Remove query properties when filtering
+      if ( ! conf.includeRemoteUrlParams) {
+        delete parsed.search
+        delete parsed.query
       }
 
       // Send entry event
       var data = {
         IsService: 'yes',
-        RemoteURL: options.socketPath || (options.protocol + '//' + options.host + options.path),
+        RemoteURL: url.format(parsed),
         HTTPMethod: (options.method || 'GET').toUpperCase()
       }
 
@@ -103,6 +106,8 @@ function patchClient (module, proto) {
 }
 
 function patchServer (module, proto) {
+  var conf = tv[proto]
+
   var fowardedHeaders = [
     'X-Forwarded-For',
     'X-Forwarded-Host',
@@ -142,14 +147,19 @@ function patchServer (module, proto) {
         var fullHost = req.headers.host || os.hostname()
         var parts = fullHost.split(':')
         var host = parts.shift()
-        var port = parts.shift() || defaultPort[proto]
+        var port = Number(parts.shift() || defaultPort[proto])
+
+        var path = req.url
+        if ( ! conf.includeRemoteUrlParams) {
+          path = path.replace(/\?.*/, '')
+        }
 
         var layer = res._http_layer = new Layer('nodejs', xtrace, {
           'ClientIP': req.socket.remoteAddress,
           'HTTP-Host': host,
           'Port': port,
           'Method': req.method,
-          'URL': req.url,
+          'URL': path,
           'Proto': proto
         })
 

--- a/test/probes/http/query-filtering.js
+++ b/test/probes/http/query-filtering.js
@@ -1,0 +1,9 @@
+exports.data = function (ctx) {
+  return {
+    url: 'http://localhost:' + ctx.data.port + '/?foo=bar'
+  }
+}
+
+exports.run = function (ctx, done) {
+  ctx.http.get(ctx.data.url, done.bind(null, null)).on('error', done)
+}

--- a/test/probes/https/query-filtering.js
+++ b/test/probes/https/query-filtering.js
@@ -1,0 +1,9 @@
+exports.data = function (ctx) {
+  return {
+    url: 'https://localhost:' + ctx.data.port + '/?foo=bar'
+  }
+}
+
+exports.run = function (ctx, done) {
+  ctx.https.get(ctx.data.url, done.bind(null, null)).on('error', done)
+}


### PR DESCRIPTION
This adds support for filtering out URL query params when reporting http(s)-client layers. Server support is next.