### PR TITLE
[hapi] Support hapi 8.5.x+

### DIFF
--- a/lib/probes/hapi.js
+++ b/lib/probes/hapi.js
@@ -69,6 +69,16 @@ function patchConnection (conn) {
   shimmer.wrap(conn, 'views',  runAndPatchView)
 }
 
+function patchGenerator (generator) {
+  shimmer.wrap(generator, 'request', function (generator) {
+    return function () {
+      var ret = generator.apply(this, arguments)
+      patchRequest(ret)
+      return ret
+    }
+  })
+}
+
 function patchRequest (request) {
   shimmer.wrap(request, '_execute', function (execute) {
     // The route argument existed from 1.2.0 and older
@@ -134,7 +144,11 @@ module.exports = function (hapi) {
   var pkg = requirePatch.relativeRequire('hapi/package.json')
 
   var Request = requirePatch.relativeRequire('hapi/lib/request')
-  patchRequest(Request.prototype)
+  if (semver.satisfies(pkg.version, '>= 8.5.0')) {
+    patchGenerator(Request.prototype)
+  } else {
+    patchRequest(Request.prototype)
+  }
 
   var Connection
   var Server

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "gulp-istanbul": "~0.9.0",
     "gulp-mocha": "~2.0.0",
     "gulp-yuidoc": "~0.1.2",
-    "hapi": "~8.4.0",
+    "hapi": "~8.6.1",
     "koa": "~0.20.0",
     "koa-resource-router": "~0.4.0",
     "koa-route": "~2.4.0",


### PR DESCRIPTION
As of hapi 8.5.0, the Request class is now constructed by calling `request` on a generator class instance.