### PR TITLE
[memcached] Ensure presence of RemoteHost k/v pair

### DIFF
--- a/lib/probes/memcached.js
+++ b/lib/probes/memcached.js
@@ -24,6 +24,9 @@ module.exports = function (memcached) {
         return command.call(this, fn)
       }
 
+      // Find server host
+      var host = this.servers && this.servers[0]
+
       // Memcached uses a builder function that returns
       // a query descriptor object. Lets patch that.
       return command.call(this, function () {
@@ -40,6 +43,7 @@ module.exports = function (memcached) {
 
         // Define entry event data
         var data = {
+          RemoteHost: host,
           KVOp: res.type,
           KVKey: key
         }

--- a/test/probes/memcached.test.js
+++ b/test/probes/memcached.test.js
@@ -40,6 +40,7 @@ describe('probes.memcached', function () {
     entry: function (msg) {
       msg.should.have.property('Layer', 'memcached')
       msg.should.have.property('Label', 'entry')
+      msg.should.have.property('RemoteHost', db_host + ':11211')
     },
     exit: function (msg) {
       msg.should.have.property('Layer', 'memcached')


### PR DESCRIPTION
Memcached wasn't including the RemoteHost key/value pair, so I added it here.