### PR TITLE
[misc] Add Spec keys to instrumentations that have defined specs

### DIFF
--- a/lib/probes/cassandra-driver.js
+++ b/lib/probes/cassandra-driver.js
@@ -83,6 +83,7 @@ function patchClient (client, consistencies) {
 
       // Create a hash to store even k/v pairs
       var data = {
+        Spec: 'query',
         Flavor: 'cql',
         Keyspace: this.options.keyspace,
         ConsistencyLevel: consistencies[consistency] || 'one',

--- a/lib/probes/fs.js
+++ b/lib/probes/fs.js
@@ -68,6 +68,7 @@ module.exports = function (fs) {
   function fdLayer (method, fd) {
     return function (layer) {
       var data = {
+        Spec: 'filesystem',
         Operation: method,
         FileDescriptor: fd
       }
@@ -118,6 +119,7 @@ module.exports = function (fs) {
         var inner
         return tv.instrument(function (layer) {
           inner = layer.descend('fs', {
+            Spec: 'filesystem',
             Operation: method,
             FilePath: path
           })
@@ -142,6 +144,7 @@ module.exports = function (fs) {
         var inner
         return tv.instrument(function (layer) {
           inner = layer.descend('fs', {
+            Spec: 'filesystem',
             Operation: syncMethod,
             FilePath: path
           })
@@ -167,6 +170,7 @@ module.exports = function (fs) {
 
         return tv.instrument(function (layer) {
           return layer.descend('fs', {
+            Spec: 'filesystem',
             Operation: method,
             FilePath: path,
             NewFilePath: dest
@@ -185,6 +189,7 @@ module.exports = function (fs) {
 
         return tv.instrument(function (layer) {
           return layer.descend('fs', {
+            Spec: 'filesystem',
             Operation: syncMethod,
             FilePath: path,
             NewFilePath: dest

--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -62,6 +62,7 @@ function patchClient (module, proto) {
 
       // Send entry event
       var data = {
+        Spec: 'rsc',
         IsService: 'yes',
         RemoteURL: url.format(parsed),
         HTTPMethod: (options.method || 'GET').toUpperCase()
@@ -155,6 +156,7 @@ function patchServer (module, proto) {
         }
 
         var layer = res._http_layer = new Layer('nodejs', xtrace, {
+          'Spec': 'ws',
           'ClientIP': req.socket.remoteAddress,
           'HTTP-Host': host,
           'Port': port,

--- a/lib/probes/levelup.js
+++ b/lib/probes/levelup.js
@@ -37,6 +37,7 @@ function patch (levelup) {
         var layer
         tv.instrument(function (last) {
           layer = last.descend('levelup', {
+            Spec: 'cache',
             KVOp: method,
             KVKey: key,
           })
@@ -69,6 +70,7 @@ function patchBatch (levelup, Batch) {
         var keys = JSON.stringify(args[0].map(getKey))
 
         return last.descend('levelup', {
+          Spec: 'cache',
           KVOp: 'batch',
           KVKeys: keys,
           KVOps: ops,
@@ -92,6 +94,7 @@ function patchBatch (levelup, Batch) {
         var keys = JSON.stringify(self.ops.map(getKey))
 
         return last.descend('levelup', {
+          Spec: 'cache',
           KVOp: 'batch',
           KVKeys: keys,
           KVOps: ops,

--- a/lib/probes/memcached.js
+++ b/lib/probes/memcached.js
@@ -43,6 +43,7 @@ module.exports = function (memcached) {
 
         // Define entry event data
         var data = {
+          Spec: 'cache',
           RemoteHost: host,
           KVOp: res.type,
           KVKey: key

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -35,6 +35,7 @@ function withCommonData (collectionName, db, data) {
   data.Collection = collectionName
   data.Database = db.databaseName
   data.Flavor = 'mongodb'
+  data.Spec = 'query'
   return data
 }
 

--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -112,6 +112,7 @@ function patchQuery (fn, Query) {
     // Set basic k/v pairs
     var cfg = this.config || this
     var data = {
+      Spec: 'query',
       Flavor: 'mysql',
       RemoteHost: cfg.host + ':' + cfg.port,
       Database: cfg.database

--- a/lib/probes/node-cassandra-cql.js
+++ b/lib/probes/node-cassandra-cql.js
@@ -115,6 +115,7 @@ function patchClient (client, version, consistencies) {
 
       // Create a hash to store even k/v pairs
       var data = {
+        Spec: 'query',
         Flavor: 'cql',
         Keyspace: this.options.keyspace,
         ConsistencyLevel: consistencies[consistency],

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -96,6 +96,7 @@ function patchConnection (conn, oracledb, options) {
 
           // Build k/v pair object
           var data = {
+            Spec: 'query',
             RemoteHost: host,
             Database: database,
             Flavor: 'oracle',

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -103,6 +103,7 @@ function patchClient (client) {
 
       // Create a hash to store even k/v pairs
       var data = {
+        Spec: 'query',
         Flavor: 'postgresql',
         RemoteHost: this.host + ':' + this.port,
         Database: this.database

--- a/lib/probes/redis.js
+++ b/lib/probes/redis.js
@@ -54,6 +54,7 @@ function patchSendCommand (client, skip) {
       }
 
       var data = {
+        Spec: 'cache',
         KVOp: cmd,
         RemoteHost: this.address || this.host + ':' + this.port
       }

--- a/lib/probes/tedious.js
+++ b/lib/probes/tedious.js
@@ -32,6 +32,7 @@ function patchConnection (connection) {
         var query = request.parametersByName.statement.value
         var config = connection.config
         var data = {
+          Spec: 'query',
           RemoteHost: config.server + ':' + config.options.port,
           Database: config.database,
           Flavor: 'mssql'


### PR DESCRIPTION
This adds spec keys to instrumentation for module types we have specs for. The template rendering spec is notably absent for now.