### PR TITLE
[error] Report socket errors without changing listener behaviour

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -1,3 +1,4 @@
+var patchEmitter = require('event-unshift')
 var extend = require('util')._extend
 var shimmer = require('shimmer')
 var url = require('url')
@@ -79,26 +80,35 @@ function patchClient (module, proto) {
         // Do request
         ret = fn(options, callback)
 
-        // Ensure the event list for the response event is an array
-        if ( ! ret._events.response) {
-          ret._events.response = []
-        } else if ( ! Array.isArray(ret._events.response)) {
-          ret._events.response = [ret._events.response]
-        }
+        // Patch emitter
+        patchEmitter(ret)
+
+        // Report socket errors
+        ret.unshift('error', function (error) {
+          layer.info({ error: error })
+        })
 
         // Ensure our exit is pushed to the FRONT of the event list
-        ret._events.response.unshift(tv.requestStore.bind(function (res) {
+        ret.unshift('response', function (res) {
           // Continue from X-Trace header, if present
           var xtrace = res.headers['x-trace']
           if (xtrace) {
             layer.events.exit.edges.push(xtrace)
           }
 
+          // Patch emitter
+          patchEmitter(res)
+
+          // Report socket errors
+          res.unshift('error', function (error) {
+            last.info({ error: error })
+          })
+
           // Send exit event with response status
           layer.exit({
             HTTPStatus: res.statusCode
           })
-        }))
+        })
       })
 
       return ret
@@ -135,6 +145,10 @@ function patchServer (module, proto) {
       if ( ! (shouldSample && tv.sample('nodejs', xtrace, meta))) {
         return realEmit.apply(this, arguments)
       }
+
+      // Patch request and response emitters to support unshifting
+      patchEmitter(req)
+      patchEmitter(res)
 
       var args = arguments
       var self = this
@@ -199,6 +213,13 @@ function patchServer (module, proto) {
           value: true
         })
         res.setHeader('X-Trace', exitEvent.toString())
+
+        // Report socket errors
+        req.unshift('error', reportError)
+        res.unshift('error', reportError)
+        function reportError (error) {
+          layer.info({ error: error })
+        }
 
         layer.enter()
         ret = realEmit.apply(self, args)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "continuation-local-storage": "~3.1.0",
     "debug": "~2.2.0",
+    "event-unshift": "^1.0.0",
     "methods": "~1.1.0",
     "minimist": "^1.2.0",
     "semver": "^5.0.1",

--- a/test/helper.js
+++ b/test/helper.js
@@ -140,7 +140,9 @@ exports.httpTest = function (emitter, test, validations, done) {
   server.listen(function () {
     var port = server.address().port
     debug('test server listening on port ' + port)
-    http.get('http://localhost:' + port).on('error', done)
+    http.get('http://localhost:' + port, function (res) {
+      res.resume()
+    }).on('error', done)
   })
 }
 
@@ -163,7 +165,9 @@ exports.httpsTest = function (emitter, options, test, validations, done) {
   server.listen(function () {
     var port = server.address().port
     debug('test server listening on port ' + port)
-    https.get('https://localhost:' + port).on('error', done)
+    https.get('https://localhost:' + port, function (res) {
+      res.resume()
+    }).on('error', done)
   })
 }
 

--- a/test/probes/http/client-object.js
+++ b/test/probes/http/client-object.js
@@ -7,5 +7,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.http.get(ctx.data, done.bind(null, null)).on('error', done)
+  ctx.http.get(ctx.data, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/http/client.js
+++ b/test/probes/http/client.js
@@ -5,5 +5,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.http.get(ctx.data.url, done.bind(null, null)).on('error', done)
+  ctx.http.get(ctx.data.url, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/http/query-filtering.js
+++ b/test/probes/http/query-filtering.js
@@ -5,5 +5,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.http.get(ctx.data.url, done.bind(null, null)).on('error', done)
+  ctx.http.get(ctx.data.url, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/http/stream.js
+++ b/test/probes/http/stream.js
@@ -6,6 +6,9 @@ exports.data = function (ctx) {
 
 exports.run = function (ctx, done) {
   var req = ctx.http.get(ctx.data.url)
-  req.on('response', done.bind(null, null))
+  req.on('response', function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  })
   req.on('error', done)
 }

--- a/test/probes/https/client-object.js
+++ b/test/probes/https/client-object.js
@@ -7,5 +7,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.https.get(ctx.data, done.bind(null, null)).on('error', done)
+  ctx.https.get(ctx.data, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/https/client.js
+++ b/test/probes/https/client.js
@@ -5,5 +5,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.https.get(ctx.data.url, done.bind(null, null)).on('error', done)
+  ctx.https.get(ctx.data.url, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/https/query-filtering.js
+++ b/test/probes/https/query-filtering.js
@@ -5,5 +5,8 @@ exports.data = function (ctx) {
 }
 
 exports.run = function (ctx, done) {
-  ctx.https.get(ctx.data.url, done.bind(null, null)).on('error', done)
+  ctx.https.get(ctx.data.url, function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  }).on('error', done)
 }

--- a/test/probes/https/stream.js
+++ b/test/probes/https/stream.js
@@ -6,6 +6,9 @@ exports.data = function (ctx) {
 
 exports.run = function (ctx, done) {
   var req = ctx.https.get(ctx.data.url)
-  req.on('response', done.bind(null, null))
+  req.on('response', function (res) {
+    res.resume()
+    res.on('end', done.bind(null, null))
+  })
   req.on('error', done)
 }


### PR DESCRIPTION
This is an attempt to report http socket errors without interfering with the error event special-case machinery.