### PR TITLE
[test] Fix hapi tests for pre-8.x versions

### DIFF
--- a/test/probes/hapi.test.js
+++ b/test/probes/hapi.test.js
@@ -104,15 +104,21 @@ describe('probes.hapi', function () {
     return server
   }
   function viewServer () {
-    return makeServer({
+    var config = {
       views: {
         path: __dirname,
-        relativeTo: __dirname,
         engines: {
           ejs: require('ejs')
         }
       }
-    })
+    }
+
+    // Avoid "not allowed" errors from pre-8.x versions
+    if (semver.satisfies(pkg.version, '>= 8.0.0')) {
+      config.relativeTo = __dirname
+    }
+
+    return makeServer(config)
   }
 
   function renderer (request, reply) {


### PR DESCRIPTION
Testing hapi against pre-8.x versions broke in another recent PR, this fixes them.