### PR TITLE
[test] Split up koa tests and ensure they work across all versions

### DIFF
--- a/lib/probes/co-render.js
+++ b/lib/probes/co-render.js
@@ -18,7 +18,7 @@ module.exports = function (render) {
       // Add rum data, when enabled
       if (tv.rumId) {
         var topLayer = tv.requestStore.get('topLayer')
-        rum.inject(opts, tv.rumId, topLayer.events.exit)
+        rum.inject(opts || {}, tv.rumId, topLayer.events.exit)
       }
 
       // Create co-render layer

--- a/lib/probes/koa-route.js
+++ b/lib/probes/koa-route.js
@@ -4,6 +4,9 @@ var Layer = require('../layer')
 
 module.exports = function (route) {
   methods.concat('del').forEach(function (method) {
+    // The method might not exist at all
+    if (typeof route[method] !== 'function') return
+
     shimmer.wrap(route, method, function (fn) {
       return function (url, route) {
         // Define controller/action at assignment time

--- a/lib/probes/koa-router.js
+++ b/lib/probes/koa-router.js
@@ -10,6 +10,9 @@ module.exports = function (router) {
       // For 5.x+, the methods are on a router, not patched onto the app
       var target = typeof handler[method] === 'function' ? handler : app
 
+      // The method might not exist at all
+      if (typeof target[method] !== 'function') return
+
       shimmer.wrap(target, method, function (fn) {
         return function (url, route) {
           // Define controller/action at assignment time

--- a/test/probes/co-render.test.js
+++ b/test/probes/co-render.test.js
@@ -1,8 +1,7 @@
 var helper = require('../helper')
 var tv = helper.tv
-var addon = tv.addon
 
-
+// Check for generator support
 var canGenerator = false
 try {
   eval('(function* () {})()')
@@ -12,7 +11,7 @@ try {
 
 function noop () {}
 
-describe('probes/koa', function () {
+describe('probes/co-render', function () {
   var emitter
   var tests = canGenerator && require('./koa')
 
@@ -41,10 +40,14 @@ describe('probes/koa', function () {
   // Tests
   //
   if ( ! canGenerator) {
-    it.skip('should support koa outer layer', noop)
+    it.skip('should support co-render', noop)
+    it.skip('should include RUM scripts', noop)
   } else {
-    it('should support koa outer layer', function (done) {
-      tests.basic(emitter, done)
+    it('should support co-render', function (done) {
+      tests.render(emitter, done)
+    })
+    it('should include RUM scripts', function (done) {
+      tests.rum(emitter, done)
     })
   }
 })

--- a/test/probes/koa-resource-router.test.js
+++ b/test/probes/koa-resource-router.test.js
@@ -12,7 +12,7 @@ try {
 
 function noop () {}
 
-describe('probes/koa', function () {
+describe('probes/koa-resource-router', function () {
   var emitter
   var tests = canGenerator && require('./koa')
 
@@ -41,10 +41,10 @@ describe('probes/koa', function () {
   // Tests
   //
   if ( ! canGenerator) {
-    it.skip('should support koa outer layer', noop)
+    it.skip('should support koa-resource-router controllers', noop)
   } else {
-    it('should support koa outer layer', function (done) {
-      tests.basic(emitter, done)
+    it('should support koa-resource-router controllers', function (done) {
+      tests.resourceRouter(emitter, done)
     })
   }
 })

--- a/test/probes/koa-route.test.js
+++ b/test/probes/koa-route.test.js
@@ -12,7 +12,7 @@ try {
 
 function noop () {}
 
-describe('probes/koa', function () {
+describe('probes/koa-route', function () {
   var emitter
   var tests = canGenerator && require('./koa')
 
@@ -41,10 +41,10 @@ describe('probes/koa', function () {
   // Tests
   //
   if ( ! canGenerator) {
-    it.skip('should support koa outer layer', noop)
+    it.skip('should support koa-route controllers', noop)
   } else {
-    it('should support koa outer layer', function (done) {
-      tests.basic(emitter, done)
+    it('should support koa-route controllers', function (done) {
+      tests.route(emitter, done)
     })
   }
 })

--- a/test/probes/koa-router.test.js
+++ b/test/probes/koa-router.test.js
@@ -12,7 +12,7 @@ try {
 
 function noop () {}
 
-describe('probes/koa', function () {
+describe('probes/koa-router', function () {
   var emitter
   var tests = canGenerator && require('./koa')
 
@@ -41,10 +41,10 @@ describe('probes/koa', function () {
   // Tests
   //
   if ( ! canGenerator) {
-    it.skip('should support koa outer layer', noop)
+    it.skip('should support koa-router controllers', noop)
   } else {
-    it('should support koa outer layer', function (done) {
-      tests.basic(emitter, done)
+    it('should support koa-router controllers', function (done) {
+      tests.router(emitter, done)
     })
   }
 })

--- a/test/probes/koa.js
+++ b/test/probes/koa.js
@@ -73,6 +73,28 @@ function controllerValidations (controller, action) {
   ]
 }
 
+exports.basic = function (emitter, done) {
+  var app = koa()
+
+  app.use(function* () {
+    this.body = 'done'
+  })
+
+  helper.doChecks(emitter, [
+    function (msg) { check['http-entry'](msg) },
+    function (msg) { check['koa-entry'](msg) },
+    function (msg) { check['koa-exit'](msg) },
+    function (msg) { check['http-exit'](msg) }
+  ], function () {
+    server.close(done)
+  })
+
+  var server = app.listen(function () {
+    var port = server.address().port
+    request('http://localhost:' + port + '/hello/world')
+  })
+}
+
 exports.route = function (emitter, done) {
   var app = koa()
 
@@ -144,11 +166,11 @@ exports.resourceRouter = function (emitter, done) {
 exports.render = function (emitter, done) {
   var app = koa()
 
-  app.use(_.get('/hello/:name', function* (name) {
+  app.use(function* () {
     this.body = yield render('hello', {
-      name: name
+      name: 'world'
     })
-  }))
+  })
 
   var validations = [
     function (msg) {
@@ -157,7 +179,6 @@ exports.render = function (emitter, done) {
     function (msg) {
       check['koa-entry'](msg)
     },
-    function () {},
     function (msg) {
       check['render-entry'](msg)
       msg.should.have.property('TemplateFile')
@@ -166,7 +187,6 @@ exports.render = function (emitter, done) {
     function (msg) {
       check['render-exit'](msg)
     },
-    function () {},
     function (msg) {
       check['koa-exit'](msg)
     },
@@ -181,7 +201,7 @@ exports.render = function (emitter, done) {
 
   var server = app.listen(function () {
     var port = server.address().port
-    request('http://localhost:' + port + '/hello/world')
+    request('http://localhost:' + port)
   })
 }
 

--- a/test/versions.js
+++ b/test/versions.js
@@ -4,17 +4,19 @@ var modules = module.exports = []
 test('bluebird')
 
 test('cassandra-driver',    '>= 0.2.0')
-test('co-render',           '*',                'gulp test:probe:koa')
+test('co-render')
 test('express',             '>= 3.0.0')
 
-// Exclude 8.3.0 due to a missing dependency bug
-test('hapi',                '>= 6.0.0 < 8.3.0 || >= 8.3.1')
-test('koa-resource-router', '*',                'gulp test:probe:koa')
-test('koa-route',           '*',                'gulp test:probe:koa')
-test('koa-router',          '*',                'gulp test:probe:koa')
+// Exclude 8.3.0 and 9.0.0 due to missing dependency bugs
+test('hapi',                '>= 6.0.0 < 8.3.0 || >= 8.3.1 < 9.0.0 || >= 9.0.1')
+test('koa-resource-router')
+test('koa-route',           '>= 1.0.1')
+test('koa-router',          '>= 1.6.0')
 test('koa')
 test('levelup',             '>= 0.17.0')
-test('memcached', version('>= 0.12.0') ? [
+test('memcached', version('>= 4.0.0') ? [
+                            '>= 0.1.1 < 1.0.0 || >= 2.2.0'
+] : version('>= 0.12.0') ? [
                             '>= 0.1.1 < 1.0.0 || >= 2.1.0'
 ] : [
                             '>= 0.1.1'


### PR DESCRIPTION
This cleans up the koa-related tests to work with node 4.x and splits them up to more easily isolate support-matrix testing.