### PR TITLE
[custom] Make custom instrumentation a no-op without liboboe

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ var bindings
 try { bindings = require('traceview-bindings') }
 catch (e) {
   console.warn('Could not find liboboe native bindings')
-  return
 }
 
 exports.addon = bindings
@@ -29,6 +28,7 @@ var reporter
 try {
   reporter = exports.reporter = new bindings.UdpReporter()
 } catch (e) {
+  reporter = exports.reporter = {}
   log('Reporter unable to connect')
 }
 
@@ -60,9 +60,9 @@ Object.defineProperty(exports, 'accessKey', {
 
 // Helper to map strings to addon keys
 var modeMap = {
-  through: bindings.TRACE_THROUGH,
-  always: bindings.TRACE_ALWAYS,
-  never: bindings.TRACE_NEVER
+  through: bindings ? bindings.TRACE_THROUGH : 2,
+  always: bindings ? bindings.TRACE_ALWAYS : 1,
+  never: bindings ? bindings.TRACE_NEVER : 0
 }
 
 /**
@@ -79,7 +79,9 @@ Object.defineProperty(exports, 'traceMode', {
       value = modeMap[value]
     }
     log('set tracing mode to ' + value)
-    bindings.Context.setTracingMode(value)
+    if (bindings) {
+      bindings.Context.setTracingMode(value)
+    }
     traceMode = value
   }
 })
@@ -94,7 +96,9 @@ Object.defineProperty(exports, 'sampleRate', {
   get: function () { return sampleRate },
   set: function (value) {
     log('set sample rate to ' + value)
-    bindings.Context.setDefaultSampleRate(value)
+    if (bindings) {
+      bindings.Context.setDefaultSampleRate(value)
+    }
     sampleRate = value
   }
 })
@@ -253,6 +257,21 @@ exports.backtrace = function ()  {
   return e.stack.replace(/^.*\n\s*/, '').replace(/\n\s*/g, '\n')
 }
 
+//
+// The remaining things require bindings to be present.
+// TODO: Make Layer, Profile and Event exportable without liboboe
+//
+if ( ! bindings) {
+  exports.sample = function () { return false }
+  exports.instrument = function (build, run, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+    }
+    run(callback)
+  }
+
+  return
+}
 
 /*!
  * Determine if the request should be sampled

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -17,6 +17,17 @@ var tv = require('..')
 //
 var soon = global.setImmediate || process.nextTick
 
+// Without the native liboboe bindings present,
+// the custom instrumentation should be a no-op
+if ( ! tv.addon) {
+  describe('custom', function () {
+    it('should passthrough without addon', function (done) {
+      tv.instrument('test', soon, done)
+    })
+  })
+  return
+}
+
 describe('custom', function () {
   var emitter
 


### PR DESCRIPTION
This is a quick attempt at making the custom instrumentation API work when liboboe is not present.