### PR TITLE
[bench] Fix hapi benchmark for 9.x+

### DIFF
--- a/test/probes/hapi.bench.js
+++ b/test/probes/hapi.bench.js
@@ -67,7 +67,17 @@ function makeServer (config) {
   config = config || {}
   var server
 
-  if (semver.satisfies(pkg.version, '>= 8.0.0-rc1')) {
+  if (semver.satisfies(pkg.version, '>= 9.0.0')) {
+    server = new hapi.Server()
+    server.register(require('vision'), function () {
+      if (config.views) {
+        server.views(config.views)
+      }
+    })
+    server.connection({
+      port: ++port
+    })
+  } else if (semver.satisfies(pkg.version, '>= 8.0.0-rc1')) {
     server = new hapi.Server()
     if (config.views) {
       server.views(config.views)


### PR DESCRIPTION
This updates the hapi benchmarks to work with hapi 9.x+.