### PR TITLE
Mongodb core instrumentation

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -168,5 +168,11 @@ module.exports = {
   director: {
     enabled: true,
     collectBacktraces: true
+  },
+
+  // https://npmjs.org/package/mongodb-core
+  'mongodb-core': {
+    enabled: true,
+    collectBacktraces: true
   }
 }

--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -1,0 +1,208 @@
+var shimmer = require('shimmer')
+var tv = require('..')
+var Layer = tv.Layer
+var Event = tv.Event
+var conf = tv['mongodb-core']
+
+module.exports = function (mongodb) {
+  patchCommands(mongodb.Server.prototype)
+  patchCommands(mongodb.ReplSet.prototype)
+  patchCommands(mongodb.Mongos.prototype)
+  patchCursor(mongodb.Cursor.prototype)
+
+  return mongodb
+}
+
+function patchCommands (obj) {
+  shimmer.wrap(obj, 'command', function (handler) {
+    return function (ns, cmd, options, callback) {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+      var fn = handler.bind(this, ns, cmd, options)
+      var self = this
+
+      return tv.instrument(function (last) {
+        return last.descend('mongodb-core', makeData(self, ns, cmd))
+      }, function (done) {
+        fn(done)
+      }, conf, callback)
+    }
+  })
+}
+
+function patchCursor (cursor) {
+  shimmer.wrap(cursor, 'next', function (handler) {
+    return function (callback) {
+      var fn = handler.bind(this)
+      var self = this
+      var layer
+
+      return tv.instrument(function (last) {
+        layer = last.descend('mongodb-core', makeData(self.topology, self.ns, self.cmd))
+        return layer
+      }, function (done) {
+        fn(function () {
+          if (layer) {
+            var e = layer.events.exit
+            e.CursorId = self.cursorState.cursorId.toString()
+            e.CursorOp = 'next'
+          }
+          done.apply(this, arguments)
+        })
+      }, conf, callback)
+    }
+  })
+}
+
+//
+// Helpers
+//
+
+// List deconstructors
+function getQuery (v) { return v.q || v.query }
+function getUpdate (v) { return v.u || v.update }
+
+// Command identifiers
+function notUndef (prop) {
+  var args = Array.prototype.slice.call(arguments)
+  return function (obj) {
+    var has = false
+    for (var i = 0; i < args.length; i++) {
+      var prop = args[i]
+      if (prop in obj || prop.toLowerCase() in obj) {
+        has = true
+      }
+    }
+    return has
+  }
+}
+
+var is = {
+  // Databases
+  dropDatabase: notUndef('dropDatabase'),
+
+  // Collections
+  createCollection: notUndef('create'),
+  renameCollection: notUndef('renameCollection'),
+  dropCollection: notUndef('dropCollection', 'drop'),
+
+  // Other
+  distinct: notUndef('distinct'),
+  count: notUndef('count'),
+
+  // Queries
+  insert: notUndef('insert'),
+  update: notUndef('update'),
+  remove: notUndef('delete'),
+
+  // Find
+  find: notUndef('find'),
+  findAndModify: notUndef('findAndModify'),
+
+  // Indexes
+  createIndexes: notUndef('createIndexes'),
+  dropIndexes: notUndef('deleteIndexes'),
+  reIndex: notUndef('reIndex'),
+
+  // Aggregation
+  group: notUndef('group'),
+  mapReduce: notUndef('mapReduce'),
+}
+
+function serverDetails (ctx) {
+  return ctx.s.serverDetails || ctx.s.replState.primary.s.serverDetails
+}
+
+function makeData (ctx, ns, cmd) {
+  var parts = ns.split('.')
+  var database = parts.shift()
+  var collection = parts.join('.')
+
+  var data = {
+    RemoteHost: serverDetails(ctx).name,
+    Collection: collection,
+    Database: database,
+    Flavor: 'mongodb',
+    Spec: 'query'
+  }
+
+  if (is.dropDatabase(cmd)) {
+    data.QueryOp = 'drop'
+
+  } else if (is.createCollection(cmd)) {
+    data.QueryOp = 'create_collection'
+    data.New_Collection_Name = cmd.create
+
+  } else if (is.renameCollection(cmd)) {
+    data.QueryOp = 'rename'
+    data.New_Collection_Name = cmd.to.split('.').slice(1).join('.')
+
+  } else if (is.dropCollection(cmd)) {
+    data.QueryOp = 'drop_collection'
+
+  } else if (is.distinct(cmd)) {
+    data.QueryOp = 'distinct'
+    data.Query = JSON.stringify(getQuery(cmd))
+    data.Key = cmd.key
+
+  } else if (is.find(cmd)) {
+    data.QueryOp = 'find'
+    data.Query = JSON.stringify(cmd.query)
+
+  } else if (is.findAndModify(cmd)) {
+    data.QueryOp = 'find_and_modify'
+    data.Query = JSON.stringify(cmd.query)
+    data.Update_Document = JSON.stringify(cmd.update)
+
+  } else if (is.insert(cmd)) {
+    data.QueryOp = 'insert'
+    data.Insert_Document = JSON.stringify(cmd.documents)
+
+  } else if (is.update(cmd)) {
+    data.QueryOp = 'update'
+    data.Query = JSON.stringify(cmd.updates.map(getQuery))
+    data.Update_Document = JSON.stringify(cmd.updates.map(getUpdate))
+
+  } else if (is.remove(cmd)) {
+    data.QueryOp = 'remove'
+    data.Query = JSON.stringify(cmd.deletes.map(getQuery))
+
+  } else if (is.count(cmd)) {
+    data.QueryOp = 'count'
+    data.Query = JSON.stringify(getQuery(cmd))
+
+  } else if (is.createIndexes(cmd)) {
+    data.QueryOp = 'create_indexes'
+    data.Indexes = JSON.stringify(cmd.indexes)
+
+  } else if (is.dropIndexes(cmd)) {
+    data.QueryOp = 'drop_indexes'
+    data.Index = JSON.stringify(cmd.index)
+
+  } else if (is.reIndex(cmd)) {
+    data.QueryOp = 'reindex'
+
+  } else if (is.group(cmd)) {
+    data.QueryOp = 'group'
+    data.Group_Condition = JSON.stringify(cmd.group.cond)
+    data.Group_Initial = JSON.stringify(cmd.group.initial)
+    data.Group_Reduce = cmd.group.$reduce.toString()
+    data.Group_Key = JSON.stringify(cmd.group.key)
+
+  } else if (is.mapReduce(cmd)) {
+    data.QueryOp = 'map_reduce'
+    data.Map_Function = cmd.map
+    data.Reduce_Function = cmd.reduce
+    if (cmd.finalize) {
+      data.Finalize_Function = cmd.finalize
+    }
+
+  } else {
+    data.QueryOp = 'command'
+    data.Command = JSON.stringify(cmd)
+  }
+
+  return data
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "levelup": "^1.2.1",
     "memcached": "^2.2.0",
     "mongodb": "^1.4.39",
+    "mongodb-core": "^1.2.19",
     "mysql": "^2.9.0",
     "node-cassandra-cql": "~0.4.4",
     "node-celery": "^0.2.3",

--- a/test/helper.js
+++ b/test/helper.js
@@ -126,15 +126,17 @@ exports.test = function (emitter, test, validations, done) {
   validations.push(noop)
   exports.doChecks(emitter, validations, done)
 
-  var layer = new tv.Layer('outer')
-  layer.async = true
-  layer.enter()
+  tv.requestStore.run(function () {
+    var layer = new tv.Layer('outer')
+    layer.async = true
+    layer.enter()
 
-  debug('test started')
-  test(function (err, data) {
-    debug('test ended')
-    if (err) return done(err)
-    layer.exit()
+    debug('test started')
+    test(function (err, data) {
+      debug('test ended')
+      if (err) return done(err)
+      layer.exit()
+    })
   })
 }
 

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -1,0 +1,600 @@
+var helper = require('../helper')
+var tv = helper.tv
+var addon = tv.addon
+
+var should = require('should')
+
+var semver = require('semver')
+var request = require('request')
+var mongodb = require('mongodb-core')
+var http = require('http')
+
+var requirePatch = require('../../lib/require-patch')
+requirePatch.disable()
+var pkg = require('mongodb-core/package.json')
+requirePatch.enable()
+
+var hosts = {
+	'2.6': process.env.TEST_MONGODB_2_6 || 'localhost:27017',
+	'3.0': process.env.TEST_MONGODB_3_0,
+	'replica set': process.env.TEST_MONGODB_SET
+}
+
+describe('probes/mongodb-core', function () {
+	Object.keys(hosts).forEach(function (host) {
+		var db_host = hosts[host]
+		if ( ! db_host) return
+		describe(host, function () {
+			makeTests(db_host, host === 'replica set')
+		})
+	})
+})
+
+function makeTests (db_host, isReplicaSet) {
+	var ctx = {}
+	var emitter
+	var db
+
+	var options = {
+		writeConcern: { w: 1 },
+		ordered: true
+	}
+
+	//
+	// Intercept tracelyzer messages for analysis
+	//
+	before(function (done) {
+    tv.fs.enabled = false
+		emitter = helper.tracelyzer(done)
+		tv.sampleRate = addon.MAX_SAMPLE_RATE
+		tv.traceMode = 'always'
+	})
+	after(function (done) {
+    tv.fs.enabled = true
+		emitter.close(done)
+	})
+
+	//
+	// Open a fresh mongodb connection for each test
+	//
+	before(function (done) {
+		var hosts = db_host.split(',').map(function (host) {
+			var parts = host.split(':')
+			var host = parts.shift()
+			var port = parts.shift()
+			return {
+				host: host,
+				port: Number(port)
+			}
+		})
+
+		var server = hosts.length > 1
+			? new mongodb.ReplSet(hosts, { setName: 'default' })
+			: new mongodb.Server({
+				host: hosts[0].host,
+				port: hosts[0].port,
+				reconnect: true,
+				reconnectInterval: 50
+			})
+
+		server.on('error', done)
+		server.on('connect', function (_db) {
+			ctx.mongo = db = _db
+			done()
+		})
+
+		server.connect()
+	})
+	before(function (done) {
+		db.command('test.$cmd', {
+			dropDatabase: 1
+		}, done)
+	})
+	after(function () {
+		db.destroy()
+	})
+
+	var check = {
+		base: function (msg) {
+			msg.should.have.property('Spec', 'query')
+			msg.should.have.property('Flavor', 'mongodb')
+			msg.should.have.property('RemoteHost')
+			msg.RemoteHost.should.match(/:\d*$/)
+		},
+		common: function (msg) {
+			msg.should.have.property('Database', 'test')
+		},
+		entry: function (msg) {
+			msg.should.have.property('Layer', 'mongodb-core')
+			msg.should.have.property('Label', 'entry')
+			check.base(msg)
+		},
+		exit: function (msg) {
+			msg.should.have.property('Layer', 'mongodb-core')
+			msg.should.have.property('Label', 'exit')
+		}
+	}
+
+	//
+	// Tests
+	//
+	var tests = {
+		databases: function () {
+			it('should drop', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'drop')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', { dropDatabase: 1 }, done)
+				}, steps, done)
+			})
+		},
+
+		collections: function () {
+			it('should create', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'create_collection')
+					msg.should.have.property('New_Collection_Name', 'test')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', { create: 'test' }, done)
+				}, steps, done)
+			})
+
+			it('should rename', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					msg.should.have.property('QueryOp', 'rename')
+					msg.should.have.property('New_Collection_Name', 'test2')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('admin.$cmd', {
+						renameCollection: 'test.test',
+						to: 'test.test2',
+						dropTarget: true
+					}, done)
+				}, steps, done)
+			})
+
+			it('should drop', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'drop_collection')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', { drop: 'test2' }, done)
+				}, steps, done)
+			})
+		},
+
+		queries: function () {
+			it('should insert', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'insert')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry, exit ]
+
+				helper.test(emitter, function (done) {
+					db.insert('test.data', [{ a: 1 }, { a: 2 }], options, done)
+				}, steps, done)
+			})
+
+			it('should update', function (done) {
+				var query = { a: 1 }
+				var update = {
+					$set: { b: 1 }
+				}
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'update')
+					msg.should.have.property('Query', JSON.stringify([query]))
+					msg.should.have.property('Update_Document', JSON.stringify([update]))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry, exit ]
+
+				helper.test(emitter, function (done) {
+					db.update('test.data', [{
+						q: query,
+						u: update
+					}], options, done)
+				}, steps, done)
+			})
+
+			it('should findAndModify', function (done) {
+				var query = { a: 1 }
+				var update = { a:1, b: 2 }
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'find_and_modify')
+					msg.should.have.property('Query', JSON.stringify(query))
+					msg.should.have.property('Update_Document', JSON.stringify(update))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.data', {
+						findAndModify: 'test.data',
+						query: query,
+						update: update,
+						new: true
+					}, options, done)
+				}, steps, done)
+			})
+
+			it('should distinct', function (done) {
+				var query = { a: 1 }
+				var key = 'b'
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'distinct')
+					msg.should.have.property('Query', JSON.stringify(query))
+					msg.should.have.property('Key', key)
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						distinct: 'test.data',
+						key: key,
+						q: query
+					}, options, done)
+				}, steps, done)
+			})
+
+			it('should count', function (done) {
+				var query = { a: 1 }
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'count')
+					msg.should.have.property('Query', JSON.stringify(query))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						count: 'test.data',
+						q: query
+					}, options, done)
+				}, steps, done)
+			})
+
+			it('should remove', function (done) {
+				var query = { a: 1 }
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'remove')
+					msg.should.have.property('Query', JSON.stringify([query]))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry, exit ]
+
+				helper.test(emitter, function (done) {
+					db.remove('test.data', [{
+						q: query,
+						limit: 1
+					}], options, done)
+				}, steps, done)
+			})
+		},
+
+		indexes: function () {
+			it('should create_indexes', function (done) {
+				var index = {
+					key: { a: 1, b: 2 },
+					name: 'data'
+				}
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'create_indexes')
+					msg.should.have.property('Indexes', JSON.stringify([index]))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						createIndexes: 'test.data',
+						indexes: [ index ]
+					}, options, done)
+				}, steps, done)
+			})
+
+			it('should reindex', function (done) {
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'reindex')
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						reIndex: 'test.data'
+					}, options, done)
+				}, steps, done)
+			})
+
+			it('should drop_indexes', function (done) {
+				var index = { a: 1, b: 2 }
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'drop_indexes')
+					msg.should.have.property('Index', JSON.stringify(index))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						deleteIndexes: 'test.data',
+						index: index
+					}, options, done)
+				}, steps, done)
+			})
+		},
+
+		cursors: function () {
+			it('should find', function (done) {
+				helper.test(emitter, function (done) {
+					var cursor = db.cursor('test.data', {
+						find: 'test.data',
+						query: { a: 1 }
+					}, options)
+					cursor.next(done)
+				}, [
+					function (msg) {
+						check.entry(msg)
+					},
+					function (msg) {
+						check.exit(msg)
+					}
+				], done)
+			})
+		},
+
+		aggregations: function () {
+			it('should group', function (done) {
+				var group = {
+					ns: 'test.data',
+					key: {},
+					initial: { count: 0 },
+					$reduce: function (doc, out) { out.count++ }.toString(),
+					out: 'inline',
+					cond: { a: { $gte: 0 } }
+				}
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'group')
+					msg.should.have.property('Group_Reduce', group.$reduce.toString())
+					msg.should.have.property('Group_Initial', JSON.stringify(group.initial))
+					msg.should.have.property('Group_Condition', JSON.stringify(group.cond))
+					msg.should.have.property('Group_Key', JSON.stringify(group.key))
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						group: group
+					}, done)
+				}, steps, done)
+			})
+
+			it('should map_reduce', function (done) {
+				function map () { emit(this.a, 1) }
+				function reduce (k, vals) { return 1 }
+
+				function entry (msg) {
+					check.entry(msg)
+					check.common(msg)
+					msg.should.have.property('QueryOp', 'map_reduce')
+					msg.should.have.property('Reduce_Function', reduce.toString())
+					msg.should.have.property('Map_Function', map.toString())
+				}
+
+				function exit (msg) {
+					check.exit(msg)
+				}
+
+				var steps = [ entry ]
+
+				if (isReplicaSet) {
+					steps.push(entry)
+					steps.push(exit)
+				}
+
+				steps.push(exit)
+
+				helper.test(emitter, function (done) {
+					db.command('test.$cmd', {
+						mapreduce: 'test.data',
+						map: map.toString(),
+						reduce: reduce.toString(),
+						out: 'inline'
+					}, done)
+				}, steps, done)
+			})
+		}
+	}
+
+	describe('databases', tests.databases)
+	describe('collections', tests.collections)
+	describe('queries', tests.queries)
+	describe('indexes', tests.indexes)
+	describe('cursors', tests.cursors)
+	describe('aggregations', tests.aggregations)
+}

--- a/test/probes/redis/pubsub.js
+++ b/test/probes/redis/pubsub.js
@@ -1,7 +1,7 @@
 var redis = require('redis')
 
 exports.run = function (ctx, done) {
-  var addr = ctx.redis.connectionOption || ctx.redis
+  var addr = ctx.redis.connectionOption || ctx.redis.options || ctx.redis
   var producer = redis.createClient(Number(addr.port), addr.host, {})
 
   ctx.redis.on('subscribe', function () {

--- a/test/versions.js
+++ b/test/versions.js
@@ -38,6 +38,9 @@ if (MONGODB_VERSION === 2) {
   ])
 }
 
+// MongoDB 2.x support is handle via mongodb-core instrumentation
+test('mongodb-core', '>= 1.1.0')
+
 test('mysql',               '> 0.9.0')
 test('node-cassandra-cql',  '>= 0.2.0')
 test('oracledb')


### PR DESCRIPTION
This provides instrumentation for `mongodb-core`, which is the lower-level driver introduced to back the 2.x range of the `mongodb` module. By instrumenting the lower-level driver, we get support for some alternate mongodb modules, and better support for identifying queried hosts.