### PR TITLE
[mysql] Support callback-less connect

### DIFF
--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -162,8 +162,13 @@ function patchConnection (conn, Query) {
   shimmer.wrap(conn, 'connect', function (fn) {
     return function () {
       var args = argsToArray(arguments)
-      var cb = args.pop()
-      args.push(tv.requestStore.bind(cb))
+      if (args.length) {
+        var cb = args.pop()
+        if (typeof cb === 'function') {
+          cb = tv.requestStore.bind(cb)
+        }
+        args.push(cb)
+      }
       return fn.apply(this, args)
     }
   })


### PR DESCRIPTION
MySQL connect function can be called without a callback.