### PR TITLE
[mongodb-core] Add 2.4 support

### DIFF
--- a/lib/probes/mongodb-core.js
+++ b/lib/probes/mongodb-core.js
@@ -1,3 +1,4 @@
+var requirePatch = require('../require-patch')
 var shimmer = require('shimmer')
 var tv = require('..')
 var Layer = tv.Layer
@@ -5,15 +6,58 @@ var Event = tv.Event
 var conf = tv['mongodb-core']
 
 module.exports = function (mongodb) {
-  patchCommands(mongodb.Server.prototype)
-  patchCommands(mongodb.ReplSet.prototype)
-  patchCommands(mongodb.Mongos.prototype)
+  var twofour = requirePatch.relativeRequire('mongodb-core/lib/wireprotocol/2_4_support')
+
+  patchCommands(mongodb.Server.prototype, twofour)
+  patchCommands(mongodb.ReplSet.prototype, twofour)
+  patchCommands(mongodb.Mongos.prototype, twofour)
   patchCursor(mongodb.Cursor.prototype)
 
   return mongodb
 }
 
-function patchCommands (obj) {
+function patchCommands (obj, twofour) {
+  function isTwoFour (ctx) {
+    return ctx.s.wireProtocolHandler instanceof twofour
+  }
+
+  function makeWrapper (name, addData) {
+    shimmer.wrap(obj, name, function (handler) {
+      return function (ns, cmd, options, callback) {
+        if (typeof options === 'function') {
+          callback = options
+          options = {}
+        }
+        var fn = handler.bind(this, ns, cmd, options)
+        var self = this
+
+        if ( ! isTwoFour(this)) {
+          return fn(callback)
+        }
+
+        return tv.instrument(function (last) {
+          var data = makeBaseData(self, ns)
+          data.QueryOp = name
+          addData(data, cmd)
+          return last.descend('mongodb-core', data)
+        }, function (done) {
+          fn(done)
+        }, conf, callback)
+      }
+    })
+  }
+
+  makeWrapper('insert', function (data, cmd) {
+    data.Insert_Document = JSON.stringify(cmd)
+  })
+  makeWrapper('update', function (data, cmd) {
+    data.Query = JSON.stringify(cmd.map(getQuery))
+    data.Update_Document= JSON.stringify(cmd.map(getUpdate))
+  })
+  makeWrapper('remove', function (data, cmd) {
+    data.Query = JSON.stringify(cmd.map(getQuery))
+  })
+
   shimmer.wrap(obj, 'command', function (handler) {
     return function (ns, cmd, options, callback) {
       if (typeof options === 'function') {
@@ -115,18 +159,22 @@ function serverDetails (ctx) {
   return ctx.s.serverDetails || ctx.s.replState.primary.s.serverDetails
 }
 
-function makeData (ctx, ns, cmd) {
+function makeBaseData (ctx, ns) {
   var parts = ns.split('.')
   var database = parts.shift()
   var collection = parts.join('.')
 
-  var data = {
+  return {
     RemoteHost: serverDetails(ctx).name,
     Collection: collection,
     Database: database,
     Flavor: 'mongodb',
     Spec: 'query'
   }
+}
+
+function makeData (ctx, ns, cmd) {
+  var data = makeBaseData(ctx, ns)
 
   if (is.dropDatabase(cmd)) {
     data.QueryOp = 'drop'

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -15,7 +15,8 @@ var pkg = require('mongodb-core/package.json')
 requirePatch.enable()
 
 var hosts = {
-	'2.6': process.env.TEST_MONGODB_2_6 || 'localhost:27017',
+	'2.4': process.env.TEST_MONGODB_2_4 || 'localhost:27017',
+	'2.6': process.env.TEST_MONGODB_2_6,
 	'3.0': process.env.TEST_MONGODB_3_0,
 	'replica set': process.env.TEST_MONGODB_SET
 }
@@ -25,12 +26,14 @@ describe('probes/mongodb-core', function () {
 		var db_host = hosts[host]
 		if ( ! db_host) return
 		describe(host, function () {
-			makeTests(db_host, host === 'replica set')
+			makeTests(db_host, host, host === 'replica set')
 		})
 	})
 })
 
-function makeTests (db_host, isReplicaSet) {
+function noop () {}
+
+function makeTests (db_host, host, isReplicaSet) {
 	var ctx = {}
 	var emitter
 	var db
@@ -401,6 +404,13 @@ function makeTests (db_host, isReplicaSet) {
 		},
 
 		indexes: function () {
+			if (host === '2.4') {
+				it.skip('should create_indexes', noop)
+				it.skip('should reindex', noop)
+				it.skip('should drop_indexes', noop)
+				return
+			}
+
 			it('should create_indexes', function (done) {
 				var index = {
 					key: { a: 1, b: 2 },
@@ -553,6 +563,11 @@ function makeTests (db_host, isReplicaSet) {
 					}, done)
 				}, steps, done)
 			})
+
+			if (host === '2.4') {
+				it.skip('should map_reduce', noop)
+				return
+			}
 
 			it('should map_reduce', function (done) {
 				function map () { emit(this.a, 1) }

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -15,7 +15,8 @@ var pkg = require('mongodb/package.json')
 requirePatch.enable()
 
 var hosts = {
-	"2.6": process.env.TEST_MONGODB_2_6 || 'localhost:27017'
+	"2.4": process.env.TEST_MONGODB_2_4 || 'localhost:27017'
+	"2.6": process.env.TEST_MONGODB_2_6
 }
 
 // Seriously mongo? Adding 3.x in a patch release?

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -144,7 +144,7 @@ function makeTests (db_host, host, self) {
 				})
 			}
 
-			if (host === '2.6' && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
+			if (/^2\.\d$/.test(host) && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
 				steps.push(noop) // nextObject entry
 				steps.push(noop) // nextObject info
 				steps.push(noop) // nextObject exit
@@ -178,7 +178,7 @@ function makeTests (db_host, host, self) {
 				})
 			}
 
-			if (host === '2.6' && semver.satisfies(pkg.version, '< 1.4.13 || >= 1.4.24')) {
+			if (/^2\.\d$/.test(host) && semver.satisfies(pkg.version, '< 1.4.13 || >= 1.4.24')) {
 				steps.push(noop) // nextObject entry
 				steps.push(noop) // nextObject info
 				steps.push(noop) // nextObject exit
@@ -538,7 +538,7 @@ function makeTests (db_host, host, self) {
 					check['info-mongodb'](msg)
 				})
 			}
-			if (host === '2.6' && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
+			if (/^2\.\d$/.test(host) && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
 				steps.push(noop) // nextObject entry
 				steps.push(noop) // nextObject info
 				steps.push(noop) // nextObject exit
@@ -587,7 +587,7 @@ function makeTests (db_host, host, self) {
 				})
 			}
 
-			if (host === '2.6' && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
+			if (/^2\.\d$/.test(host) && semver.satisfies(pkg.version, '< 1.4.11 || >= 1.4.24')) {
 				steps.push(noop) // nextObject entry
 				steps.push(noop) // nextObject info
 				steps.push(noop) // nextObject exit

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -15,7 +15,7 @@ var pkg = require('mongodb/package.json')
 requirePatch.enable()
 
 var hosts = {
-	"2.4": process.env.TEST_MONGODB_2_4 || 'localhost:27017'
+	"2.4": process.env.TEST_MONGODB_2_4 || 'localhost:27017',
 	"2.6": process.env.TEST_MONGODB_2_6
 }
 


### PR DESCRIPTION
The mongodb-core work was lacking 2.4 support. This addresses that and adds automated testing for it.