### PR TITLE
[mongodb] Disable instrumentation for versions using mongodb-core

### DIFF
--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -12,19 +12,12 @@ module.exports = function (mongodb) {
   var pkg = requirePatch.relativeRequire('mongodb/package.json')
 
   // Skip instrumentation on unsupported versions
-  if (semver.satisfies(pkg.version, '>=1.2.9')) {
-    var Cursor = semver.satisfies(pkg.version, '>= 2.0.0')
-      ? requirePatch.relativeRequire('mongodb/lib/cursor')
-      : mongodb.Cursor
-
+  if (semver.satisfies(pkg.version, '>=1.2.9 < 2')) {
     patchCollection(mongodb.Collection, pkg.version)
-    patchCursor(Cursor, pkg.version)
+    patchCursor(mongodb.Cursor, pkg.version)
     patchDb(mongodb.Db, pkg.version)
-
-    if (semver.satisfies(pkg.version, '< 2')) {
-      patchCheckout(mongodb.ReplSet.prototype)
-      patchCheckout(mongodb.Server.prototype)
-    }
+    patchCheckout(mongodb.ReplSet.prototype)
+    patchCheckout(mongodb.Server.prototype)
   }
 
   return mongodb


### PR DESCRIPTION
This prevents double reporting when the lower-level driver is also reporting.