### PR TITLE
[test] Support starting docker test services directly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+require 'json'
+
 #
 # This Vagrantfile builds a dev box with all the parts needed for testing
 #
@@ -52,81 +54,7 @@ Vagrant.configure(2) do |config|
     nfs: true, mount_options: ['nolock,vers=3,udp']
 
   config.vm.provision 'docker' do |d|
-    images = [
-      {
-        name: 'mysql',
-        ports: [3306],
-        env: {
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
-          MYSQL_ROOT_PASSWORD: ''
-        }
-      },
-      {
-        name: 'mongo_2_4',
-        image: 'mongo',
-        ports: [27017],
-        tag: '2.4'
-      },
-      {
-        name: 'mongo_2_6',
-        image: 'mongo',
-        ports: [[27018,27017]],
-        tag: '2.6'
-      },
-      {
-        name: 'mongo_3',
-        image: 'mongo',
-        ports: [[27019,27017]],
-        tag: '3'
-      },
-      {
-        name: 'mongo_replset',
-        image: 'appnetaqa/mongo',
-        ports: [[27020,27017],[27021,27018],[27022,27019]],
-        tag: 'set',
-        env: {
-          REPLSETMEMBERS: 3
-        }
-      },
-      {
-        name: 'redis',
-        ports: [6379]
-      },
-      {
-        name: 'postgres',
-        ports: [5432],
-        env: {
-          POSTGRES_PASSWORD: ''
-        }
-      },
-      {
-        name: 'cassandra',
-        ports: [9042]
-      },
-      {
-        name: 'rabbitmq',
-        ports: [5672]
-      },
-      {
-        name: 'memcached',
-        ports: [11211]
-      },
-      {
-        name: 'oracle',
-        image: 'sath89/oracle-xe-11g',
-        ports: [8080,1521]
-      },
-      {
-        name: 'mssql',
-        image: 'rsmoorthy/sql2000',
-        ports: [1433]
-      },
-      # {
-      #   name: 'rethinkdb',
-      #   ports: [8080]
-      # },
-    ]
-
+    images = JSON.parse(File.read('docker-containers.json'))
     images.each do |image|
       # Determine name
       name = image[:name]

--- a/docker-containers.json
+++ b/docker-containers.json
@@ -1,0 +1,78 @@
+[
+	{
+		"name": "mysql",
+		"ports": [3306],
+		"env": {
+			"MYSQL_ALLOW_EMPTY_PASSWORD": "yes",
+			"MYSQL_ROOT_PASSWORD": ""
+		}
+	},
+	{
+		"name": "mongo_2_4",
+		"image": "mongo",
+		"ports": [27017],
+		"tag": "2.4"
+	},
+	{
+		"name": "mongo_2_6",
+		"image": "mongo",
+		"ports": [
+			[27018,27017]
+		],
+		"tag": "2.6"
+	},
+	{
+		"name": "mongo_3",
+		"image": "mongo",
+		"ports": [
+			[27019,27017]
+		],
+		"tag": "3"
+	},
+	{
+		"name": "mongo_replset",
+		"image": "appnetaqa/mongo",
+		"ports": [
+			[27020,27017],
+			[27021,27018],
+			[27022,27019]
+		],
+		"tag": "set",
+		"env": {
+			"REPLSETMEMBERS": 3
+		}
+	},
+	{
+		"name": "redis",
+		"ports": [6379]
+	},
+	{
+		"name": "postgres",
+		"ports": [5432],
+		"env": {
+			"POSTGRES_PASSWORD": ""
+		}
+	},
+	{
+		"name": "cassandra",
+		"ports": [9042]
+	},
+	{
+		"name": "rabbitmq",
+		"ports": [5672]
+	},
+	{
+		"name": "memcached",
+		"ports": [11211]
+	},
+	{
+		"name": "oracle",
+		"image": "sath89/oracle-xe-11g",
+		"ports": [8080,1521]
+	},
+	{
+		"name": "mssql",
+		"image": "rsmoorthy/sql2000",
+		"ports": [1433]
+	}
+]

--- a/docker.rb
+++ b/docker.rb
@@ -1,0 +1,100 @@
+require 'json'
+require 'ostruct'
+
+class Port
+	attr_accessor :from, :to
+
+	def initialize(port)
+		if port.is_a?(Array)
+			@from = port[0]
+			@to = port[1]
+		elsif port.is_a?(Integer)
+			@from = @to = port
+		elsif port.is_a?(Hash)
+			@from = port[:from]
+			@to = port[:to]
+		else
+			raise 'unrecognized port format'
+		end
+	end
+
+	def to_s
+		"-p #{@from}:#{@to}"
+	end
+end
+
+class Env
+	attr_accessor :vars
+
+	def initialize(vars)
+		@vars = vars
+	end
+
+	def to_s
+		list = []
+		@vars.each do |key, value|
+			list << "-e #{key}=#{value}"
+		end
+		list.join ' '
+	end
+end
+
+class TaggedImage
+	attr_accessor :name, :image, :tag
+
+	def initialize(data)
+		@tag = data[:tag]
+		@name = data[:name]
+		@image = data[:image].nil? ? @name : data[:image]
+	end
+
+	def to_s
+		full_image
+	end
+
+	private
+
+	def image_name
+		@image.nil? ? @name : @image
+	end
+
+	def full_image
+		name = image_name
+		@tag.nil? ? name : "#{name}:#{@tag}"
+	end
+end
+
+class Image
+	attr_accessor :name, :image, :ports
+
+	def initialize(data)
+		@name = data[:name]
+		@image = TaggedImage.new(data)
+		@env = Env.new(data[:env] || Hash.new)
+		@ports = (data[:ports] || []).map { |port| Port.new(port) } || []
+	end
+
+	def to_s
+		args = []
+		port_args = @ports.map { |port| port.to_s }
+		args += port_args unless port_args.nil?
+
+		"docker run -d --name #{@name} #{args.join ' '} #{@env.to_s} #{@image.to_s}"
+	end
+
+	def self.load(path)
+		parse(File.read(path))
+	end
+	def self.parse(data)
+		JSON.parse(data, symbolize_names: true).map do |image|
+			Image.new(image)
+		end
+	end
+end
+
+images = Image.load('docker-containers.json')
+images.each do |cmd|
+	v = cmd.to_s
+	puts v
+	system v
+end


### PR DESCRIPTION
The container details have now been moved to a shared json file at `docker-containers.json`, which can be used by both the `Vagrantfile` and `docker.rb` to spin up the necessary test containers.