### PR TITLE
http: Fix httpServer.setTimeout(...) exit event leak

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -149,6 +149,7 @@ function patchServer (module, proto) {
       // Patch request and response emitters to support unshifting
       patchEmitter(req)
       patchEmitter(res)
+      patchEmitter(res.socket)
 
       var args = arguments
       var self = this
@@ -221,6 +222,19 @@ function patchServer (module, proto) {
           layer.info({ error: error })
         }
 
+        var end = once(function end () {
+          if (Event.last && Event.last !== layer.events.entry && ! Event.last.Async) {
+            layer.events.exit.edges.push(Event.last)
+          }
+
+          layer.exit({
+            Status: this.statusCode
+          })
+        })
+
+        res.socket.unshift('close', end)
+        res.unshift('finish', end)
+
         layer.enter()
         ret = realEmit.apply(self, args)
       })
@@ -229,29 +243,14 @@ function patchServer (module, proto) {
     }
   })
 
-  // Patch ServerResponse to send the exit event when the
-  // response is completed or the connection is terminated
-  if (proto == 'http' && ! module.ServerResponse.prototype._sendXTraceExit) {
-    module.ServerResponse.prototype._sendXTraceExit = function () {
-      var layer = this._http_layer
-      if ( ! layer) return
-
-      if (Event.last && Event.last !== layer.events.entry && ! Event.last.Async) {
-        layer.events.exit.edges.push(Event.last)
-      }
-
-      layer.exit({
-        Status: this.statusCode
-      })
-    }
-
-    shimmer.wrap(module.ServerResponse.prototype, 'detachSocket', function (fn) {
-      return function (socket) {
-        this._sendXTraceExit()
-        return fn.call(this, socket)
-      }
-    })
-  }
-
   return module
+}
+
+function noop () {}
+function once (fn) {
+  return function () {
+    var v = fn()
+    fn = noop
+    return v
+  }
 }

--- a/test/probes/http.test.js
+++ b/test/probes/http.test.js
@@ -324,6 +324,41 @@ describe('probes.http', function () {
         request('http://localhost:' + port + '/foo?bar=baz')
       })
     })
+
+    //
+    // Validate that server.setTimeout(...) exits correctly
+    //
+    it('should exit when timed out', function (done) {
+      var server = http.createServer(function (req, res) {
+        setTimeout(function () {
+          res.end('done')
+        }, 20)
+      })
+
+      // Set timeout
+      var reached = false
+      server.setTimeout(10)
+      server.on('timeout', function () {
+        reached = true
+      })
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          check.server.entry(msg)
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        reached.should.equal(true)
+        server.close(done)
+      })
+
+      server.listen(function () {
+        var port = server.address().port
+        request('http://localhost:' + port)
+      })
+    })
   })
 
   describe('http-client', function () {


### PR DESCRIPTION
This fixes an issue that caused the nodejs layer from http or https servers to never send the exit event, holding the liboboe event for it in memory indefinitely.