### PR TITLE
move array-flatten to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "gypfile": true,
   "dependencies": {
+    "array-flatten": "1.1.1",
     "continuation-local-storage": "~3.1.0",
     "debug": "~2.2.0",
     "event-unshift": "^1.0.0",
@@ -54,7 +55,6 @@
   "devDependencies": {
     "alltheversions": "~1.0.0",
     "amqp": "~0.2.4",
-    "array-flatten": "1.1.1",
     "bluebird": "^2.9.32",
     "body-parser": "^1.13.3",
     "bson": "^0.4.11",


### PR DESCRIPTION
@Qard I just realized my PR had "array-flatten" in devDependencies instead of dependencies. :( Because of this 2.4.4 is broken. Should be an easy fix. Sorry about that.