### PR TITLE
add test and fix for reporting events from layers created with layer.profile

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -55,6 +55,7 @@ Profile.prototype.init = function (name, parent, data) {
 
   // Store the events for later use
   this.events = {
+    internal: [],
     entry: entry,
     exit: exit
   }

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -57,4 +57,18 @@ describe('profile', function () {
       })
     })
   })
+
+  it('should allow error/info reporting from profile layer', function () {
+    var layer = new Layer('test2', null, {})
+    layer.run(function () {
+      var profile = layer.profile('test2-profile')
+
+      profile.should.be.instanceof(Profile)
+      profile.should.have.property('events')
+      profile.events.should.have.property('internal')
+
+      tv.reportError(new Error('test error'))
+      tv.reportInfo({ Foo: 'bar' })
+    })
+  })
 })


### PR DESCRIPTION
While trying to report error events in an express controller later I was running into an exception because layer.events.internal was undefined. I added a test to reproduce the issue and verify the fix.