### PR TITLE
layer, event, error: Fix internal event chaining

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -3,6 +3,7 @@ var logEnter = require('debug')('traceview:event:enter')
 var logChange = require('debug')('traceview:event:change')
 var logEdge = require('debug')('traceview:event:edge')
 var logError = require('debug')('traceview:event:error')
+var logSet = require('debug')('traceview:event:set')
 
 var extend = require('util')._extend
 var tv = require('./')
@@ -73,10 +74,20 @@ function Event (layer, label, parent) {
  * @property error
  * @type {Error}
  */
-Event.prototype.__defineSetter__('error', function (err) {
-  this.ErrorClass = err.constructor.name
-  this.ErrorMsg = err.message
-  this.Backtrace = err.stack
+Object.defineProperty(Event.prototype, 'error', {
+  set: function (err) {
+    logSet(this + ' setting error')
+
+    if ( ! (err instanceof Error)) {
+      logSet(this + ' tried to set error with non-error type')
+      return
+    }
+
+    this.ErrorClass = err.constructor.name
+    this.ErrorMsg = err.message
+    this.Backtrace = err.stack
+    logSet(this + ' set error to "' + this.ErrorMsg + '"')
+  }
 })
 
 /**
@@ -86,8 +97,10 @@ Event.prototype.__defineSetter__('error', function (err) {
  * @type {String}
  * @readOnly
  */
-Event.prototype.__defineGetter__('taskId', function () {
-  return this.event.toString().substr(2, 40)
+Object.defineProperty(Event.prototype, 'taskId', {
+  get: function () {
+    return this.event.toString().substr(2, 40)
+  }
 })
 
 /**
@@ -97,8 +110,10 @@ Event.prototype.__defineGetter__('taskId', function () {
  * @type {String}
  * @readOnly
  */
-Event.prototype.__defineGetter__('opId', function () {
-  return this.event.toString().substr(42)
+Object.defineProperty(Event.prototype, 'opId', {
+  get: function () {
+    return this.event.toString().substr(42)
+  }
 })
 
 /**
@@ -107,20 +122,22 @@ Event.prototype.__defineGetter__('opId', function () {
  * @property last
  * @type {Event}
  */
-Event.__defineGetter__('last', function () {
-  var last
-  try {
-    last = tv.requestStore.get('lastEvent')
-  } catch (e) {
-    logError('Can not access continuation-local-storage. Context may be lost.')
-  }
-  return last
-})
-Event.__defineSetter__('last', function (value) {
-  try {
-    tv.requestStore.set('lastEvent', value)
-  } catch (e) {
-    logError('Can not access continuation-local-storage. Context may be lost.')
+Object.defineProperty(Event, 'last', {
+  get: function () {
+    var last
+    try {
+      last = tv.requestStore.get('lastEvent')
+    } catch (e) {
+      logError('Can not access continuation-local-storage. Context may be lost.')
+    }
+    return last
+  },
+  set: function (value) {
+    try {
+      tv.requestStore.set('lastEvent', value)
+    } catch (e) {
+      logError('Can not access continuation-local-storage. Context may be lost.')
+    }
   }
 })
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -78,8 +78,13 @@ Object.defineProperty(Event.prototype, 'error', {
   set: function (err) {
     logSet(this + ' setting error')
 
+    // Allow string errors
+    if (typeof err === 'string') {
+      err = new Error(err)
+    }
+
     if ( ! (err instanceof Error)) {
-      logSet(this + ' tried to set error with non-error type')
+      logSet(this + ' tried to set error with non-error, non-string type')
       return
     }
 

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -70,20 +70,22 @@ Layer.prototype.init = function (name, parent, data) {
  * @property last
  * @type {Layer}
  */
-Layer.__defineGetter__('last', function () {
-  var last
-  try {
-    last = tv.requestStore.get('lastLayer')
-  } catch (e) {
-    debug('Can not access continuation-local-storage. Context may be lost.')
-  }
-  return last
-})
-Layer.__defineSetter__('last', function (value) {
-  try {
-    tv.requestStore.set('lastLayer', value)
-  } catch (e) {
-    debug('Can not access continuation-local-storage. Context may be lost.')
+Object.defineProperty(Layer, 'last', {
+  get: function () {
+    var last
+    try {
+      last = tv.requestStore.get('lastLayer')
+    } catch (e) {
+      debug('Can not access continuation-local-storage. Context may be lost.')
+    }
+    return last
+  },
+  set: function (value) {
+    try {
+      tv.requestStore.set('lastLayer', value)
+    } catch (e) {
+      debug('Can not access continuation-local-storage. Context may be lost.')
+    }
   }
 })
 
@@ -129,17 +131,19 @@ Layer.prototype.profile = function (name, data) {
  * @property async
  * @type {Boolean}
  */
-Layer.prototype.__defineSetter__('async', function (val) {
-  this._async = val
-  if (val) {
-    this.events.entry.Async = true
-  } else {
-    delete this.events.entry.Async
+Object.defineProperty(Layer.prototype, 'async', {
+  set: function (val) {
+    this._async = val
+    if (val) {
+      this.events.entry.Async = true
+    } else {
+      delete this.events.entry.Async
+    }
+    debug(this.name + ' layer ' + (val ? 'enabled' : 'disabled') + ' async')
+  },
+  get: function () {
+    return this._async
   }
-  debug(this.name + ' layer ' + (val ? 'enabled' : 'disabled') + ' async')
-})
-Layer.prototype.__defineGetter__('async', function () {
-  return this._async
 })
 
 /**
@@ -275,16 +279,20 @@ Layer.prototype.exit = function (data) {
 /*!
  * Create and send an internal event
  *
- *     layer.internal({ Foo: 'bar' })
+ *     layer._internal('info', { Foo: 'bar' })
  *
  * @method _internal
  * @param {String} label Event type label
  * @param {Object} data Key/Value pairs to add to event
  */
 Layer.prototype._internal = function (label, data) {
-  debug(this.name + ' layer ' + label)
+  var last = Event.last
+  if ( ! last) {
+    debug(this.name + ' layer ' + label + ' call could not find last event')
+    return
+  }
 
-  var event = new Event(null, label, this.events.entry)
+  var event = new Event(null, label, last)
   this.events.internal.push(event)
 
   // Mixin data, when available
@@ -303,7 +311,20 @@ Layer.prototype._internal = function (label, data) {
  * @param {Object} data Key/Value pairs to add to event
  */
 Layer.prototype.info = function (data) {
+  debug(this.name + ' layer info call')
+
+  // Skip sending non-objects
+  if ( ! isRealObject(data)) {
+    debug('invalid input to layer.info(...)')
+    return
+  }
+
   this._internal('info', data)
+}
+
+// Helper to identify object literals
+function isRealObject (v) {
+ return Object.prototype.toString.call(v) === '[object Object]'
 }
 
 /**
@@ -315,6 +336,8 @@ Layer.prototype.info = function (data) {
  * @param {Object} data Key/Value pairs to add to event
  */
 Layer.prototype.error = function (error) {
+  debug(this.name + ' layer error call')
+
   // Allow string errors
   if (typeof error === 'string') {
     error = new Error(error)
@@ -322,6 +345,7 @@ Layer.prototype.error = function (error) {
 
   // Skip sending non-errors
   if ( ! (error instanceof Error)) {
+    debug('invalid input to layer.error(...)')
     return
   }
 

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,5 +1,6 @@
 var helper = require('./helper')
 var tv = require('..')
+var Layer = tv.Layer
 var Event = tv.Event
 
 describe('error', function () {
@@ -50,6 +51,18 @@ describe('error', function () {
     event.should.have.property('ErrorClass', 'Error')
     event.should.have.property('ErrorMsg', err.message)
     event.should.have.property('Backtrace', err.stack)
+  })
+
+  it('should set error multiple times (keeping last)', function () {
+    var event = new Event('error-test', 'info')
+    var first = new Error('first')
+    var second = new Error('second')
+    event.error = first
+    event.error = second
+
+    event.should.have.property('ErrorClass', 'Error')
+    event.should.have.property('ErrorMsg', second.message)
+    event.should.have.property('Backtrace', second.stack)
   })
 
   it('should report errors in sync calls', function (done) {
@@ -119,6 +132,55 @@ describe('error', function () {
         msg.Edge.should.equal(last)
       }
     ], done)
+  })
+
+  it('should support string errors', function (done) {
+    var error = 'test'
+    helper.httpTest(emitter, function (done) {
+      tv.reportError(error)
+      done()
+    }, [
+      function (msg) {
+        msg.should.not.have.property('Layer')
+        msg.should.have.property('Label', 'error')
+        msg.should.have.property('ErrorClass', 'Error')
+        msg.should.have.property('ErrorMsg', error)
+        msg.should.have.property('Backtrace')
+      }
+    ], done)
+  })
+
+  it('should fail silently when given non-error, non-string types', function () {
+    var layer = new Layer('test', null, {})
+    layer._internal = function () {
+      throw new Error('should not have triggered an _internal call')
+    }
+    layer.error({ foo: 'bar' })
+    layer.error(undefined)
+    layer.error(new Date)
+    layer.error(/foo/)
+    layer.error(null)
+    layer.error([])
+    layer.error(1)
+  })
+
+  it('should allow sending the same error multiple times', function (done) {
+    var error = new Error('dupe')
+
+    // TODO: validate edge chaining
+    function validate (msg) {
+      msg.should.not.have.property('Layer')
+      msg.should.have.property('Label', 'error')
+      msg.should.have.property('ErrorClass', 'Error')
+      msg.should.have.property('ErrorMsg', error.message)
+      msg.should.have.property('Backtrace', error.stack)
+    }
+
+    helper.httpTest(emitter, function (done) {
+      tv.reportError(error)
+      tv.reportError(error)
+      done()
+    }, [ validate, validate ], done)
   })
 
 })

--- a/test/layer.test.js
+++ b/test/layer.test.js
@@ -3,6 +3,7 @@ var should = require('should')
 var tv = require('..')
 var addon = tv.addon
 var Layer = tv.Layer
+var Event = tv.Event
 
 describe('layer', function () {
   var emitter
@@ -298,17 +299,229 @@ describe('layer', function () {
     }
 
     var checks = [
+      function () {},
       function (msg) {
+        msg.should.not.have.property('Layer')
         msg.should.have.property('Label', 'info')
-
         Object.keys(data).forEach(function (key) {
           msg.should.have.property(key, data[key])
         })
-      }
+      },
+      function () {}
     ]
 
     helper.doChecks(emitter, checks, done)
 
-    layer.info(data)
+    layer.run(function () {
+      layer.info(data)
+    })
   })
+
+  it('should not send info events when not in a layer', function () {
+    var layer = new Layer('test', null, {})
+    var data = { Foo: 'bar' }
+
+    var send = Event.prototype.send
+    Event.prototype.send = function () {
+      Event.prototype.send = send
+      throw new Error('should not send when not in a layer')
+    }
+
+    layer.info(data)
+    Event.prototype.send = send
+  })
+
+  it('should allow sending the same info data multiple times', function (done) {
+    var layer = new Layer('test', null, {})
+    var e = layer.events.entry
+    var data = {
+      Foo: 'bar'
+    }
+
+    function check (msg) {
+      msg.should.not.have.property('Layer')
+      msg.should.have.property('Label', 'info')
+      Object.keys(data).forEach(function (key) {
+        msg.should.have.property(key, data[key])
+      })
+    }
+
+    helper.doChecks(emitter, [
+      function () {},
+      check,
+      check,
+      function () {}
+    ], done)
+
+    layer.run(function () {
+      layer.info(data)
+      layer.info(data)
+    })
+  })
+
+  it('should fail silently when sending non-object-literal info', function () {
+    var layer = new Layer('test', null, {})
+    layer._internal = function () {
+      throw new Error('should not have triggered an _internal call')
+    }
+    layer.info(undefined)
+    layer.info(new Date)
+    layer.info(/foo/)
+    layer.info('wat')
+    layer.info(null)
+    layer.info([])
+    layer.info(1)
+  })
+
+  it('should chain internal event edges', function (done) {
+    var layer = new Layer('test', null, {})
+
+    var n = 10 + Math.floor(Math.random() * 10)
+    var msgs = []
+
+    function push (msg) {
+      msgs.push(msg)
+    }
+
+    var checks = [ push, push ]
+    for (var i = 0; i < n; i++) {
+      checks.push(push)
+    }
+
+    helper.doChecks(emitter, checks, function (err) {
+      if (err) return done(err)
+      var prev = msgs.shift()
+      msgs.forEach(function (event) {
+        linksTo(event, prev)
+        prev = event
+      })
+      done()
+    })
+
+    function sendAThing (i) {
+      if (Math.random() > 0.5) {
+        layer.error(new Error('error ' + i))
+      } else {
+        layer.info({ index: i })
+      }
+    }
+
+    layer.run(function () {
+      for (var i = 0; i < n; i++) {
+        sendAThing(i)
+      }
+    })
+  })
+
+  it('should chain internal events around sync sub layer', function (done) {
+    var layer = new Layer('outer', null, {})
+
+    var before = { state: 'before' }
+    var after = { state: 'after' }
+
+    var track = edgeTracker()
+
+    var checks = [
+      checkEntry('outer', track),
+        checkInfo(before, track),
+        checkEntry('inner', track),
+        checkExit('inner', track),
+        checkInfo(after, track),
+      checkExit('outer', track)
+    ]
+
+    helper.doChecks(emitter, checks, done)
+
+    layer.run(function () {
+      layer.info(before)
+      layer.descend('inner').run(function () {
+        // Do nothing
+      })
+      layer.info(after)
+    })
+  })
+
+  it('should chain internal events around async sub layer', function (done) {
+    var layer = new Layer('outer', null, {})
+
+    var before = { state: 'before' }
+    var after = { state: 'after' }
+
+    var trackOuter = edgeTracker()
+    var trackInner = edgeTracker()
+
+    var checks = [
+      checkEntry('outer', trackOuter),
+        checkInfo(before, trackOuter),
+
+        // Async call
+        checkEntry('inner', trackInner),
+        checkInfo(before, trackInner),
+
+        checkInfo(after, trackOuter),
+      checkExit('outer', trackOuter),
+
+        // Next tick
+        checkInfo(after, trackInner),
+        checkExit('inner', trackInner)
+    ]
+
+    helper.doChecks(emitter, checks, done)
+
+    layer.run(function () {
+      layer.info(before)
+      var sub = layer.descend('inner')
+      sub.run(function (wrap) {
+        var cb = wrap(function () {})
+        setImmediate(function () {
+          tv.reportInfo(after)
+          cb()
+        })
+        tv.reportInfo(before)
+      })
+      layer.info(after)
+    })
+  })
+
 })
+
+function linksTo (a, b) {
+  a.Edge.should.eql(b['X-Trace'].substr(42))
+}
+
+function edgeTracker () {
+  var last = null
+  return function (msg) {
+    if (last) linksTo(msg, last)
+    last = msg
+  }
+}
+
+function checkEntry (name, fn) {
+  return function (msg) {
+    msg.should.have.property('X-Trace')
+    msg.should.have.property('Label', 'entry')
+    msg.should.have.property('Layer', name)
+    if (fn) fn(msg)
+  }
+}
+
+function checkExit (name, fn) {
+  return function (msg) {
+    msg.should.have.property('X-Trace')
+    msg.should.have.property('Label', 'exit')
+    msg.should.have.property('Layer', name)
+    if (fn) fn(msg)
+  }
+}
+
+function checkInfo (data, fn) {
+  return function (msg) {
+    msg.should.not.have.property('Layer')
+    msg.should.have.property('Label', 'info')
+    Object.keys(data).forEach(function (key) {
+      msg.should.have.property(key, data[key])
+    })
+    if (fn) fn(msg)
+  }
+}

--- a/test/layer.test.js
+++ b/test/layer.test.js
@@ -247,6 +247,39 @@ describe('layer', function () {
     })
   })
 
+  it('should only send valid properties', function (done) {
+    var layer = new Layer('test', null, {})
+    var e = layer.events.entry
+    var data = {
+      Array: [],
+      Object: { bar: 'baz' },
+      Function: function () {},
+      Date: new Date,
+      String: 'bix'
+    }
+
+    var expected = {
+      String: 'bix'
+    }
+
+    var checks = [
+      helper.checkEntry('test'),
+      helper.checkInfo(expected, function (msg) {
+        msg.should.not.have.property('Object')
+        msg.should.not.have.property('Array')
+        msg.should.not.have.property('Function')
+        msg.should.not.have.property('Date')
+      }),
+      helper.checkExit('test'),
+    ]
+
+    helper.doChecks(emitter, checks, done)
+
+    layer.run(function () {
+      layer.info(data)
+    })
+  })
+
   it('should not send info events when not in a layer', function () {
     var layer = new Layer('test', null, {})
     var data = { Foo: 'bar' }

--- a/test/layer.test.js
+++ b/test/layer.test.js
@@ -46,21 +46,13 @@ describe('layer', function () {
     var e = layer.events
 
     var checks = [
-      function (msg) {
+      helper.checkEntry(name, helper.checkData(data, function (msg) {
         msg.should.have.property('X-Trace', e.entry.toString())
-        msg.should.have.property('Label', 'entry')
-        msg.should.have.property('Layer', name)
-
-        Object.keys(data).forEach(function (key) {
-          msg.should.have.property(key, data[key])
-        })
-      },
-      function (msg) {
+      })),
+      helper.checkExit(name, function (msg) {
         msg.should.have.property('X-Trace', e.exit.toString())
         msg.should.have.property('Edge', e.entry.opId)
-        msg.should.have.property('Label', 'exit')
-        msg.should.have.property('Layer', name)
-      }
+      })
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -79,22 +71,14 @@ describe('layer', function () {
 
     var checks = [
       // Verify structure of entry event
-      function (msg) {
+      helper.checkEntry(name, helper.checkData(data, function (msg) {
         msg.should.have.property('X-Trace', e.entry.toString())
-        msg.should.have.property('Label', 'entry')
-        msg.should.have.property('Layer', name)
-
-        Object.keys(data).forEach(function (key) {
-          msg.should.have.property(key, data[key])
-        })
-      },
+      })),
       // Verify structure of exit event
-      function (msg) {
+      helper.checkExit(name, function (msg) {
         msg.should.have.property('X-Trace', e.exit.toString())
         msg.should.have.property('Edge', e.entry.opId)
-        msg.should.have.property('Label', 'exit')
-        msg.should.have.property('Layer', name)
-      }
+      })
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -120,37 +104,21 @@ describe('layer', function () {
     var outer, inner
 
     var checks = [
-      function (msg) {
+      helper.checkEntry('outer', helper.checkData(outerData, function (msg) {
         msg.should.have.property('X-Trace', outer.events.entry.toString())
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(outerData).forEach(function (key) {
-          msg.should.have.property(key, outerData[key])
-        })
-      },
-      function (msg) {
+      })),
+      helper.checkEntry('inner', helper.checkData(innerData, function (msg) {
         msg.should.have.property('X-Trace', inner.events.entry.toString())
         msg.should.have.property('Edge', outer.events.entry.opId.toString())
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(innerData).forEach(function (key) {
-          msg.should.have.property(key, innerData[key])
-        })
-      },
-      function (msg) {
+      })),
+      helper.checkExit('inner', function (msg) {
         msg.should.have.property('X-Trace', inner.events.exit.toString())
         msg.should.have.property('Edge', inner.events.entry.opId.toString())
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'exit')
-      },
-      function (msg) {
+      }),
+      helper.checkExit('outer', function (msg) {
         msg.should.have.property('X-Trace', outer.events.exit.toString())
         msg.should.have.property('Edge', inner.events.exit.opId.toString())
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'exit')
-      }
+      })
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -169,40 +137,24 @@ describe('layer', function () {
 
     var checks = [
       // Outer entry
-      function (msg) {
+      helper.checkEntry('outer', helper.checkData(outerData, function (msg) {
         msg.should.have.property('X-Trace', outer.events.entry.toString())
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(outerData).forEach(function (key) {
-          msg.should.have.property(key, outerData[key])
-        })
-      },
+      })),
       // Inner entry (async)
-      function (msg) {
+      helper.checkEntry('inner', helper.checkData(innerData, function (msg) {
         msg.should.have.property('X-Trace', inner.events.entry.toString())
         msg.should.have.property('Edge', outer.events.entry.opId)
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(innerData).forEach(function (key) {
-          msg.should.have.property(key, innerData[key])
-        })
-      },
+      })),
       // Outer exit
-      function (msg) {
+      helper.checkExit('outer', function (msg) {
         msg.should.have.property('X-Trace', outer.events.exit.toString())
         msg.should.have.property('Edge', outer.events.entry.opId)
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'exit')
-      },
+      }),
       // Inner exit (async)
-      function (msg) {
+      helper.checkExit('inner', function (msg) {
         msg.should.have.property('X-Trace', inner.events.exit.toString())
         msg.should.have.property('Edge', inner.events.entry.opId)
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'exit')
-      }
+      })
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -231,40 +183,24 @@ describe('layer', function () {
 
     var checks = [
       // Outer entry (async)
-      function (msg) {
+      helper.checkEntry('outer', helper.checkData(outerData, function (msg) {
         msg.should.have.property('X-Trace', outer.events.entry.toString())
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(outerData).forEach(function (key) {
-          msg.should.have.property(key, outerData[key])
-        })
-      },
+      })),
       // Outer exit (async)
-      function (msg) {
+      helper.checkExit('outer', function (msg) {
         msg.should.have.property('X-Trace', outer.events.exit.toString())
         msg.should.have.property('Edge', outer.events.entry.opId)
-        msg.should.have.property('Layer', 'outer')
-        msg.should.have.property('Label', 'exit')
-      },
+      }),
       // Inner entry
-      function (msg) {
+      helper.checkEntry('inner', helper.checkData(innerData, function (msg) {
         msg.should.have.property('X-Trace', inner.events.entry.toString())
         msg.should.have.property('Edge', outer.events.exit.opId)
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'entry')
-
-        Object.keys(innerData).forEach(function (key) {
-          msg.should.have.property(key, innerData[key])
-        })
-      },
+      })),
       // Inner exit
-      function (msg) {
+      helper.checkExit('inner', function (msg) {
         msg.should.have.property('X-Trace', inner.events.exit.toString())
         msg.should.have.property('Edge', inner.events.entry.opId)
-        msg.should.have.property('Layer', 'inner')
-        msg.should.have.property('Label', 'exit')
-      },
+      })
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -299,15 +235,9 @@ describe('layer', function () {
     }
 
     var checks = [
-      function () {},
-      function (msg) {
-        msg.should.not.have.property('Layer')
-        msg.should.have.property('Label', 'info')
-        Object.keys(data).forEach(function (key) {
-          msg.should.have.property(key, data[key])
-        })
-      },
-      function () {}
+      helper.checkEntry('test'),
+      helper.checkInfo(data),
+      helper.checkExit('test'),
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -338,19 +268,11 @@ describe('layer', function () {
       Foo: 'bar'
     }
 
-    function check (msg) {
-      msg.should.not.have.property('Layer')
-      msg.should.have.property('Label', 'info')
-      Object.keys(data).forEach(function (key) {
-        msg.should.have.property(key, data[key])
-      })
-    }
-
     helper.doChecks(emitter, [
-      function () {},
-      check,
-      check,
-      function () {}
+      helper.checkEntry('test'),
+      helper.checkInfo(data),
+      helper.checkInfo(data),
+      helper.checkExit('test'),
     ], done)
 
     layer.run(function () {
@@ -374,29 +296,16 @@ describe('layer', function () {
   })
 
   it('should chain internal event edges', function (done) {
-    var layer = new Layer('test', null, {})
-
     var n = 10 + Math.floor(Math.random() * 10)
-    var msgs = []
+    var layer = new Layer('test', null, {})
+    var tracker = helper.edgeTracker()
 
-    function push (msg) {
-      msgs.push(msg)
-    }
-
-    var checks = [ push, push ]
+    var checks = [ tracker, tracker ]
     for (var i = 0; i < n; i++) {
-      checks.push(push)
+      checks.push(tracker)
     }
 
-    helper.doChecks(emitter, checks, function (err) {
-      if (err) return done(err)
-      var prev = msgs.shift()
-      msgs.forEach(function (event) {
-        linksTo(event, prev)
-        prev = event
-      })
-      done()
-    })
+    helper.doChecks(emitter, checks, done)
 
     function sendAThing (i) {
       if (Math.random() > 0.5) {
@@ -419,15 +328,15 @@ describe('layer', function () {
     var before = { state: 'before' }
     var after = { state: 'after' }
 
-    var track = edgeTracker()
+    var track = helper.edgeTracker()
 
     var checks = [
-      checkEntry('outer', track),
-        checkInfo(before, track),
-        checkEntry('inner', track),
-        checkExit('inner', track),
-        checkInfo(after, track),
-      checkExit('outer', track)
+      helper.checkEntry('outer', track),
+        helper.checkInfo(before, track),
+        helper.checkEntry('inner', track),
+        helper.checkExit('inner', track),
+        helper.checkInfo(after, track),
+      helper.checkExit('outer', track)
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -447,23 +356,23 @@ describe('layer', function () {
     var before = { state: 'before' }
     var after = { state: 'after' }
 
-    var trackOuter = edgeTracker()
-    var trackInner = edgeTracker()
+    var trackOuter = helper.edgeTracker()
+    var trackInner = helper.edgeTracker()
 
     var checks = [
-      checkEntry('outer', trackOuter),
-        checkInfo(before, trackOuter),
+      helper.checkEntry('outer', trackOuter),
+        helper.checkInfo(before, trackOuter),
 
         // Async call
-        checkEntry('inner', trackInner),
-        checkInfo(before, trackInner),
+        helper.checkEntry('inner', trackInner),
+        helper.checkInfo(before, trackInner),
 
-        checkInfo(after, trackOuter),
-      checkExit('outer', trackOuter),
+        helper.checkInfo(after, trackOuter),
+      helper.checkExit('outer', trackOuter),
 
         // Next tick
-        checkInfo(after, trackInner),
-        checkExit('inner', trackInner)
+        helper.checkInfo(after, trackInner),
+        helper.checkExit('inner', trackInner)
     ]
 
     helper.doChecks(emitter, checks, done)
@@ -483,45 +392,75 @@ describe('layer', function () {
     })
   })
 
-})
+  it('should properly attribute dangling info/error events', function (done) {
+    var layer = new Layer('outer', null, {})
 
-function linksTo (a, b) {
-  a.Edge.should.eql(b['X-Trace'].substr(42))
-}
+    var before = { state: 'before' }
+    var after = { state: 'after' }
+    var error = new Error('wat')
 
-function edgeTracker () {
-  var last = null
-  return function (msg) {
-    if (last) linksTo(msg, last)
-    last = msg
-  }
-}
+    var trackOuter = helper.edgeTracker()
+    var trackInner1 = helper.edgeTracker(trackOuter)
+    var trackInner2 = helper.edgeTracker(trackOuter)
+    var trackInner3 = helper.edgeTracker(trackInner1)
+    var trackInner4 = helper.edgeTracker(trackInner3)
 
-function checkEntry (name, fn) {
-  return function (msg) {
-    msg.should.have.property('X-Trace')
-    msg.should.have.property('Label', 'entry')
-    msg.should.have.property('Layer', name)
-    if (fn) fn(msg)
-  }
-}
+    var checks = [
+      helper.checkEntry('outer', trackOuter),
 
-function checkExit (name, fn) {
-  return function (msg) {
-    msg.should.have.property('X-Trace')
-    msg.should.have.property('Label', 'exit')
-    msg.should.have.property('Layer', name)
-    if (fn) fn(msg)
-  }
-}
+        // Async call
+        helper.checkEntry('inner-1', trackInner1),
+        helper.checkEntry('inner-2', trackInner2),
 
-function checkInfo (data, fn) {
-  return function (msg) {
-    msg.should.not.have.property('Layer')
-    msg.should.have.property('Label', 'info')
-    Object.keys(data).forEach(function (key) {
-      msg.should.have.property(key, data[key])
+        // Next tick
+        helper.checkExit('inner-1', trackInner1),
+          helper.checkInfo(after, trackInner1),
+          helper.checkEntry('inner-3', trackInner3),
+          helper.checkInfo(after, trackInner1),
+        helper.checkExit('inner-2', trackInner2),
+
+      // Faked sync exit
+      helper.checkExit('outer', trackInner2),
+
+          // Delayed until after fake sync exit
+          helper.checkExit('inner-3', trackInner3),
+            helper.checkError(error, trackInner3),
+            helper.checkEntry('inner-4', trackInner4),
+            helper.checkExit('inner-4', trackInner4),
+    ]
+
+    helper.doChecks(emitter, checks, done)
+
+    tv.requestStore.run(function () {
+      layer.enter()
+      var sub1 = layer.descend('inner-1')
+      sub1.run(function (wrap) {
+        setImmediate(wrap(function () {
+          tv.reportInfo(after)
+
+          var sub2 = layer.descend('inner-3')
+          sub2.run(function (wrap) {
+            setImmediate(wrap(function () {
+              tv.reportError(error)
+
+              var sub2 = layer.descend('inner-4')
+              sub2.run(function (wrap) {
+                setImmediate(wrap(function () {}))
+              })
+            }))
+          })
+
+          tv.reportInfo(after)
+        }))
+      })
+
+      var sub2 = layer.descend('inner-2')
+      sub2.run(function (wrap) {
+        setTimeout(wrap(function () {
+          layer.exit()
+        }), 1)
+      })
     })
-    if (fn) fn(msg)
-  }
-}
+  })
+
+})


### PR DESCRIPTION
This fixes makes internal events chain properly, makes sub layers link correctly around internal events and expands the test suite around the behaviour of how internal events work and the custom instrumentation interfaces to create them manually.