### PR TITLE
bcrypt: Add patch to propagate CLS

### DIFF
--- a/lib/probes/bcrypt.js
+++ b/lib/probes/bcrypt.js
@@ -1,0 +1,27 @@
+var shimmer = require('shimmer')
+var slice = require('sliced')
+var tv = require('..')
+
+module.exports = function (bcrypt) {
+  var methods = [
+    'compare',
+    'genSalt',
+    'hash'
+  ]
+
+  methods.forEach(function (method) {
+    shimmer.wrap(bcrypt, method, patchCallback)
+  })
+
+  return bcrypt
+}
+
+function patchCallback (fn) {
+  return function () {
+    var args = slice(arguments)
+    if (tv.tracing) {
+      args.push(tv.requestStore.bind(args.pop()))
+    }
+    return fn.apply(this, args)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "alltheversions": "~1.0.0",
     "amqp": "~0.2.4",
+    "bcrypt": "^0.8.5",
     "bluebird": "^2.9.32",
     "body-parser": "^1.13.3",
     "bson": "^0.4.11",

--- a/test/probes/bcrypt.test.js
+++ b/test/probes/bcrypt.test.js
@@ -1,0 +1,25 @@
+var helper = require('../helper')
+var tv = helper.tv
+
+var bcrypt = require('bcrypt')
+
+describe('probes/bcrypt', function () {
+  it('should trace through async bcrypt', function (done) {
+    tv.requestStore.run(function () {
+      // Hack to look like there's a previous layer
+      tv.requestStore.set('lastEvent', true)
+
+      var password = 'this is a test'
+      tv.requestStore.set('foo', 'bar')
+      
+      bcrypt.genSalt(10, function (err, salt) {
+        bcrypt.hash(password, salt, function (err, hash) {
+          bcrypt.compare(password, hash, function (err, res) {
+            tv.requestStore.get('foo').should.equal('bar')
+            done()
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/versions.js
+++ b/test/versions.js
@@ -1,6 +1,7 @@
 var semver = require('semver')
 var modules = module.exports = []
 
+test('bcrypt',              '>= 0.7.4')
 test('bluebird')
 
 test('cassandra-driver',    '>= 0.2.0')


### PR DESCRIPTION
This adds support for propagating the CLS context through bcrypt.