### PR TITLE
generic-pool: Patched to propagate CLS context

### DIFF
--- a/lib/probes/generic-pool.js
+++ b/lib/probes/generic-pool.js
@@ -1,0 +1,33 @@
+var shimmer = require('shimmer')
+var tv = require('..')
+
+module.exports = function (genericPool) {
+  if (genericPool.Pool.prototype.acquire) {
+    patchAcquire(genericPool.Pool.prototype)
+  } else {
+    patchPool(genericPool)
+  }
+
+  return genericPool
+}
+
+function patchPool (obj) {
+  shimmer.wrap(obj, 'Pool', function (fn) {
+    return function (factory) {
+      var pool = fn.call(this, factory)
+      patchAcquire(pool)
+      return pool
+    }
+  })
+}
+
+function patchAcquire (obj) {
+  shimmer.wrap(obj, 'acquire', function (fn) {
+    return function (callback, priority) {
+      if (tv.tracing) {
+        callback = tv.requestStore.bind(callback)
+      }
+      return fn.call(this, callback, priority)
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "director": "^1.2.8",
     "ejs": "~2.3.1",
     "express": "^4.13.3",
+    "generic-pool": "^2.4.1",
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.0",
     "gulp-matcha": "^1.0.3",

--- a/test/probes/generic-pool.test.js
+++ b/test/probes/generic-pool.test.js
@@ -1,0 +1,43 @@
+var helper = require('../helper')
+var tv = helper.tv
+
+var Pool = require('generic-pool').Pool
+
+var foo = { bar: 'baz' }
+
+var pool = new Pool({
+  name: 'test',
+  create: function (cb) {
+    cb(null, foo)
+  },
+  max: 1,
+  min: 1
+})
+
+describe('probes/generic-pool', function () {
+  it('should trace through generic-pool acquire', function (done) {
+    var acquiring = false
+
+    pool.acquire(function (err, foo2) {
+      var t = setInterval(function () {
+        if (acquiring) {
+          pool.release(foo2)
+          clearInterval(t)
+        }
+      }, 10)
+    })
+
+    tv.requestStore.run(function () {
+      // Hack to look like there's a previous layer
+      tv.requestStore.set('lastEvent', true)
+
+      tv.requestStore.set('foo', 'bar')
+      pool.acquire(function (err) {
+        tv.requestStore.get('foo').should.equal('bar')
+        done()
+      })
+    })
+
+    acquiring = true
+  })
+})

--- a/test/versions.js
+++ b/test/versions.js
@@ -9,6 +9,8 @@ test('co-render')
 test('director',            '>= 1.1.10')
 test('express',             '>= 3.0.0')
 
+test('generic-pool',        '>= 1.0.3')
+
 // Exclude 8.3.0 and 9.0.0 due to missing dependency bugs
 test('hapi',                '>= 6.0.0 < 8.3.0 || >= 8.3.1 < 9.0.0 || >= 9.0.1')
 test('koa-resource-router')


### PR DESCRIPTION
This patches generic-pool, which provides the underlying pooling mechanism for many different modules and was previously causing CLS to lose context any time `pool.acquire(...)` was called while a connection was not immediately ready.