### PR TITLE
mongoose, test: Update mongoose patches and test it better

### DIFF
--- a/lib/probes/mongoose.js
+++ b/lib/probes/mongoose.js
@@ -3,9 +3,32 @@ var shimmer = require('shimmer')
 var tv = require('..')
 
 module.exports = function (mongoose) {
-  shimmer.wrap(mongoose.Collection.prototype, 'addQueue', function (addQueue) {
+  patchCollectionAddQueue(mongoose)
+  patchSchemaAddQueue(mongoose)
+  patchExec(mongoose)
+  patchWrapCallback(mongoose)
+  patchOn(mongoose)
+
+  return mongoose
+}
+
+function patchCollectionAddQueue (mongoose) {
+  if ( ! mongoose.Collection) return
+  if ( ! mongoose.Collection.prototype) return
+  if ( ! mongoose.Collection.prototype.addQueue) return
+  patchAddQueue(mongoose.Collection.prototype)
+}
+
+function patchSchemaAddQueue (mongoose) {
+  if ( ! mongoose.Schema) return
+  if ( ! mongoose.Schema.prototype) return
+  if ( ! mongoose.Schema.prototype.addQueue) return
+  patchAddQueue(mongoose.Schema.prototype)
+}
+
+function patchAddQueue (obj) {
+  shimmer.wrap(obj, 'addQueue', function (addQueue) {
     return function (name, args) {
-      // Try to patch queued calls, if possible
       var last = args[args.length - 1]
       if (typeof last === 'function') {
         args[args.length - 1] = tv.requestStore.bind(last)
@@ -13,6 +36,52 @@ module.exports = function (mongoose) {
       return addQueue.call(this, name, args)
     }
   })
+}
 
-  return mongoose
+function patchExec (mongoose) {
+  if ( ! mongoose.Query) return
+  if ( ! mongoose.Query.prototype) return
+  if ( ! mongoose.Query.prototype.exec) return
+
+  shimmer.wrap(mongoose.Query.prototype, 'exec', function (exec) {
+    return function (op, callback) {
+      if (typeof op == 'function') {
+        op = tv.requestStore.bind(op)
+      }
+      if (typeof callback == 'function') {
+        callback = tv.requestStore.bind(callback)
+      }
+      return exec.call(this, op, callback)
+    }
+  })
+}
+
+function patchWrapCallback (mongoose) {
+  if ( ! mongoose.Query) return
+  if ( ! mongoose.Query.base) return
+  if ( ! mongoose.Query.base._wrapCallback) return
+
+  shimmer.wrap(mongoose.Query.base, '_wrapCallback', function (_wrapCallback) {
+    return function (method, callback, queryInfo) {
+      if (typeof callback == 'function') {
+        callback = tv.requestStore.bind(callback)
+      }
+      return _wrapCallback.call(this, method, callback, queryInfo)
+    }
+  })
+}
+
+function patchOn (mongoose) {
+  if ( ! mongoose.Promise) return
+  if ( ! mongoose.Promise.prototype) return
+  if ( ! mongoose.Promise.prototype.on) return
+
+  shimmer.wrap(mongoose.Promise.prototype, 'on', function (on) {
+    return function (event, callback) {
+      if (typeof callback == 'function') {
+        callback = tv.requestStore.bind(callback)
+      }
+      return on.call(this, event, callback)
+    }
+  })
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "memcached": "^2.2.0",
     "mongodb": "^1.4.39",
     "mongodb-core": "^1.2.19",
+    "mongoose": "^4.4.5",
     "mysql": "^2.9.0",
     "node-cassandra-cql": "~0.4.4",
     "node-celery": "^0.2.3",

--- a/test/probes/mongoose.test.js
+++ b/test/probes/mongoose.test.js
@@ -1,0 +1,42 @@
+var helper = require('../helper')
+var tv = helper.tv
+var Layer = tv.Layer
+
+var mongoose = require('mongoose')
+var Schema = mongoose.Schema
+
+var host = process.env.TEST_MONGODB_2_4 || 'localhost:27017'
+
+describe('probes/mongoose', function () {
+  var Cat = mongoose.model('test', new Schema({
+    name: String
+  }))
+
+  before(function (done) {
+    mongoose.connect('mongodb://' + host + '/test', done)
+  })
+  after(function() {
+    mongoose.disconnect()
+  })
+
+  it('should trace through mongoose', function (done) {
+    var layer = new Layer('outer', {})
+    layer.run(function () {
+      var data = {
+        name: 'Sargeant Cuddlesby'
+      }
+
+      var password = 'this is a test'
+      tv.requestStore.set('name', data.name)
+
+      var kitty = new Cat(data)
+      kitty.save(function (err) {
+        tv.requestStore.get('name').should.equal(data.name)
+        Cat.findOne(data, function () {
+          tv.requestStore.get('name').should.equal(data.name)
+          done()
+        })
+      })
+    })
+  })
+})

--- a/test/probes/node-cassandra-cql.test.js
+++ b/test/probes/node-cassandra-cql.test.js
@@ -55,8 +55,10 @@ describe('probes.cassandra', function () {
       emitter = helper.tracelyzer(done)
       tv.sampleRate = tv.addon.MAX_SAMPLE_RATE
       tv.traceMode = 'always'
+      tv.fs.enabled = false
     })
     after(function (done) {
+      tv.fs.enabled = true
       emitter.close(done)
     })
 

--- a/test/versions.js
+++ b/test/versions.js
@@ -43,6 +43,8 @@ if (MONGODB_VERSION === 2) {
 // MongoDB 2.x support is handle via mongodb-core instrumentation
 test('mongodb-core', '>= 1.1.0')
 
+test('mongoose',     '>= 2.2.1 < 4.2 || >= 4.2.2')
+
 test('mysql',               '> 0.9.0')
 test('node-cassandra-cql',  '>= 0.2.0')
 test('oracledb')


### PR DESCRIPTION
This updates the mongoose patches to work up to the latest version of mongoose and adds some proper testing of the CLS context propagation.