### PR TITLE
test: Support semaphore CI environment vars

### DIFF
--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -13,6 +13,8 @@ var pkg = require('mysql/package.json')
 var mysql = require('mysql')
 
 var addr = Address.from(process.env.TEST_MYSQL || 'localhost:3306')[0]
+var user = process.env.TEST_MYSQL_USERNAME || process.env.DATABASE_MYSQL_USERNAME || 'root'
+var pass = process.env.TEST_MYSQL_PASSWORD || process.env.DATABASE_MYSQL_PASSWORD || ''
 var soon = global.setImmediate || process.nextTick
 
 describe('probes.mysql', function () {
@@ -75,8 +77,8 @@ describe('probes.mysql', function () {
     var db = makeDb({
       host: addr.host,
       port: addr.port,
-      user: process.env.TEST_MYSQL_USERNAME || 'root',
-      password: process.env.TEST_MYSQL_PASSWORD
+      user: user,
+      password: pass
     }, function (err) {
       if (err) return done(err)
       db.query('CREATE DATABASE IF NOT EXISTS test;', function (err) {
@@ -92,8 +94,8 @@ describe('probes.mysql', function () {
       host: addr.host,
       port: addr.port,
       database: 'test',
-      user: process.env.TEST_MYSQL_USERNAME || 'root',
-      password: process.env.TEST_MYSQL_PASSWORD
+      user: user,
+      password: pass
     }, function (err) {
       if (err) return done(err)
       db.query('CREATE TABLE IF NOT EXISTS test (foo varchar(255));', done)
@@ -106,8 +108,8 @@ describe('probes.mysql', function () {
         host: addr.host,
         port: addr.port,
         database: 'test',
-        user: process.env.TEST_MYSQL_USERNAME || 'root',
-        password: process.env.TEST_MYSQL_PASSWORD
+        user: user,
+        password: pass
       }
 
       pool = db.pool = mysql.createPool(poolConfig)

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -13,8 +13,8 @@ var addr = helper.Address.from(process.env.TEST_POSTGRES || 'localhost:5432')[0]
 var auth = {
   host: addr.host,
   port: addr.port,
-  user: process.env.TEST_POSTGRES_USERNAME || 'postgres',
-  password: process.env.TEST_POSTGRES_PASSWORD,
+  user: process.env.TEST_POSTGRES_USERNAME || process.env.DATABASE_POSTGRESQL_USERNAME || 'postgres',
+  password: process.env.TEST_POSTGRES_PASSWORD || process.env.DATABASE_POSTGRESQL_PASSWORD,
   database: 'test'
 }
 


### PR DESCRIPTION
Semaphore CI requires the use of some different env variables to connect to mysql and postgres. This adds that to the tests.