### PR TITLE
custom: Add tv.startAndContinueTrace(...) and tv.traceId

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,7 @@ Object.defineProperty(exports, 'log', {
   set: function (value) {
     if (value !== log) {
       log = value
-      
+
       if (typeof value === 'string') {
         value = value.split(',')
       }
@@ -300,6 +300,20 @@ Object.defineProperty(exports, 'tracing', {
 })
 
 /**
+ * X-Trace ID of the last event
+ *
+ * @property traceId
+ * @type String
+ * @readOnly
+ */
+Object.defineProperty(exports, 'traceId', {
+  get: function () {
+    var last = Event && Event.last
+    if (last) return last.toString()
+  }
+})
+
+/**
  * Generate a backtrace string
  *
  * @method backtrace
@@ -318,10 +332,10 @@ if ( ! enabled) {
   exports.reportInfo = noop
   exports.sample = function () { return false }
   exports.instrument = function (build, run, options, callback) {
-    if (typeof options === 'function') {
-      callback = options
-    }
-    run(callback)
+    return run(typeof options === 'function' ? options : callback)
+  }
+  exports.startOrContinueTrace = function (xtrace, build, run, options, callback) {
+    return run(typeof options === 'function' ? options : callback)
   }
 
   return
@@ -376,12 +390,12 @@ exports.sample = function (layer, xtrace, meta) {
  *     tv.instrument(builder, runner, callback)
  *
  * @method instrument
- * @param {String} build                        Layer name or builder function
- * @param {String} run                          Code to instrument and run
- * @param {Object} [options]                    Options
- * @param {Object} [options.enabled]            Enable tracing, on by default
- * @param {Object} [options.collectBacktraces]  Enable tracing, on by default
- * @param {Object} callback                     Callback
+ * @param {String|Function}  build                        Layer name or builder function
+ * @param {String}           run                          Code to instrument and run
+ * @param {Object}           [options]                    Options
+ * @param {Boolean}          [options.enabled]            Enable tracing, on by default
+ * @param {Boolean}          [options.collectBacktraces]  Enable tracing, on by default
+ * @param {Function}         [callback]                   Callback, if async
  */
 exports.instrument = function (build, run, options, callback) {
   if (typeof options !== 'object') {
@@ -407,14 +421,23 @@ exports.instrument = function (build, run, options, callback) {
     return run(callback)
   }
 
+  return runInstrument(last, build, run, options, callback)
+}
+
+// This builds a layer descending from the supplied layer using the arguments
+// expected of a tv.instrument(), tv.startTrace() or tv.continueTrace() call.
+function runInstrument (last, build, run, options, callback) {
   // Prepare builder function
   var builder = typeof build === 'function' ? build : function (last) {
     return last.descend(build)
   }
 
-  // Build layer
-  var layer = builder(last)
+  // Build and run layer
+  return runLayer(builder(last), run, options, callback)
+}
 
+// Set backtrace, if configured to do so, and run the already constructed layer
+function runLayer (layer, run, options, callback) {
   // Attach backtrace, if enabled
   if (options.collectBacktraces) {
     layer.events.entry.Backtrace = exports.backtrace(4)
@@ -429,6 +452,77 @@ exports.instrument = function (build, run, options, callback) {
 }
 
 function noop () {}
+
+/**
+ * Start or continue a trace
+ *
+ * @method startOrContinueTrace
+ * @param {String}           xtrace                       X-Trace ID to continue from
+ * @param {String|Function}  build                        Layer name or builder function
+ * @param {String}           run                          Code to instrument and run
+ * @param {Object}           [options]                    Options
+ * @param {Boolean}          [options.enabled]            Enable tracing, on by default
+ * @param {Boolean}          [options.collectBacktraces]  Enable tracing, on by default
+ * @param {Function}         [callback]                   Callback, if async
+ */
+exports.startOrContinueTrace = function (xtrace, build, run, options, callback) {
+  if (typeof options !== 'object') {
+    callback = options
+    options = { enabled: true }
+  }
+
+  if ( ! callback && run.length) {
+    callback = noop
+  }
+
+  // If not enabled, skip
+  if ( ! options.enabled) {
+    if (callback) {
+      callback = exports.requestStore.bind(callback)
+    }
+    return run(callback)
+  }
+
+  // If already tracing, continue the existing trace.
+  var last = Layer.last
+  if (last) {
+    return runInstrument(last, build, run, options, callback)
+  }
+
+  // Build data
+  var data = typeof build === 'function' ? build({
+    descend: layerDataMaker(Layer),
+    profile: layerDataMaker(Profile)
+  }) : { name: build, cons: Layer }
+
+  // Do sampling
+  var shouldSample = xtrace || exports.always
+  if ( ! (shouldSample && exports.sample(data.name, xtrace))) {
+    return run(callback)
+  }
+
+  // Now make the actual layer
+  var layer = new data.cons(data.name, xtrace, data.data)
+
+  // Add sampling data to entry
+  if ( ! xtrace) {
+    var entry = layer.events.entry
+    entry.SampleSource = exports.sampleSource
+    entry.SampleRate = exports.sampleRate
+  }
+
+  return runLayer(layer, run, options, callback)
+}
+
+// This is a helper to map layer.descend(...) and layer.profile(...) calls
+// to the data provided to them, rather than producing layers or profiles
+// directly. This allows acquiring the layer name before sampling, without
+// creating a layer until after sampling.
+function layerDataMaker (cons) {
+  return function (name, data) {
+    return { name: name, data: data, cons: cons }
+  }
+}
 
 
 /**


### PR DESCRIPTION
This adds support for starting a fresh trace or continuing a remote trace, with sampling applied.