### PR TITLE
core: Change default trace mode to always

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,7 +8,7 @@ module.exports = {
   // - always - When no instrumented outer layer is present
   // - never - When you don't want any tracing to occur
   //
-  traceMode: 'through',
+  traceMode: 'always',
 
   //
   // Host and port of tracelyzer to report to.


### PR DESCRIPTION
We've determined we want the default trace mode to be "always", going forward. This is a semver-major change.