### PR TITLE
core: Fix issue with sample data reassigning sample rate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -353,8 +353,8 @@ exports.sample = function (layer, xtrace, meta) {
   var rv = bindings.Context.sampleRequest(layer, xtrace || '', meta || '')
   if ( ! rv[0] && exports.skipSample) return [1,1,1]
   if ( ! rv[0]) return false
-  exports.sampleSource = rv[1]
-  exports.sampleRate = rv[2]
+  sampleSource = rv[1]
+  sampleRate = rv[2]
   return rv
 }
 

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -99,6 +99,27 @@ describe('basics', function () {
     tv.skipSample = skipSample
   })
 
+  it('should not call sampleRate setter from sample function', function () {
+    tv.sampleRate = tv.addon.MAX_SAMPLE_RATE
+    tv.traceMode = 'always'
+    var skipSample = tv.skipSample
+    tv.skipSample = false
+
+    function after (err) {
+      tv.addon.Context.setDefaultSampleRate = old
+      tv.skipSample = skipSample
+    }
+
+    var old = tv.addon.Context.setDefaultSampleRate
+    tv.addon.Context.setDefaultSampleRate = function () {
+      after()
+      throw new Error('Should not have called sampleRate setter')
+    }
+
+    tv.sample('test')
+    after()
+  })
+
   it('should not trace in through without xtrace header', function (done) {
     tv.sampleRate = tv.addon.MAX_SAMPLE_RATE
     tv.traceMode = 'through'


### PR DESCRIPTION
The `tv.sample(...)` function was assigning directly to `tv.sampleRate`, which is the setter for specifying a manual sample rate. This is incorrect behaviour and has therefore been fixed.