### PR TITLE
amqp: Support pushq and job specs

### DIFF
--- a/lib/probes/amqp.js
+++ b/lib/probes/amqp.js
@@ -78,24 +78,29 @@ function patchQueueSubscribe (proto) {
       let refCb = trueCb
 
       return fn.call(queue, options, function (msg) {
-        const xid = msg && msg.headers && msg.headers.SourceTrace
+        const SourceTrace = msg && msg.headers && msg.headers.SourceTrace
 
         if (!refCb) {
           refCb = queue.consumerTagListeners[msg.consumerTag]
         }
 
         return tv.startOrContinueTrace(
-          xid,
+          { meta: SourceTrace },
           last => {
             const { host, port } = queue.connection.options
+            const fnName = util.fnName(refCb)
             return last.descend('amqp', {
               Spec: 'job',
               Flavor: 'amqp',
-              JobName: util.fnName(refCb),
-              RemoteHost: `${host}:${port}`,
+              JobName: fnName,
+              Queue: queue.name,
               MsgID: msg.consumerTag,
               RoutingKey: msg.routingKey,
-              Queue: queue.name,
+              RemoteHost: `${host}:${port}`,
+              URL: `/amqp/${queue.name}`,
+              Controller: 'amqp',
+              Action: fnName,
+              SourceTrace
             })
           },
           (done, layer) => {

--- a/lib/probes/amqp.js
+++ b/lib/probes/amqp.js
@@ -2,6 +2,7 @@
 
 const WeakMap = require('es6-weak-map')
 const shimmer = require('shimmer')
+const util = require('../util')
 const tv = require('..')
 const conf = tv.amqp
 
@@ -33,10 +34,105 @@ function patchQueue (proto) {
     if (args.length) args.push(tv.bind(args.pop()))
     const res = queue.apply(this, args)
     const proto = res && res.constructor && res.constructor.prototype
-    if (proto) patchEmitterOnUse(proto)
+    if (proto) {
+      patchQueueSubscribe(proto)
+      patchEmitterOnUse(proto)
+    }
     tv.bindEmitter(res)
     return res
   })
+}
+
+const patchedQueue = new WeakMap()
+function patchQueueSubscribe (proto) {
+  if (patchedQueue.get(proto)) return
+  patchedQueue.set(proto, true)
+
+  // This is used to propagate the callback name forward
+  // from the subscribe patch into the subscribeRaw patch.
+  let trueCb
+  if (typeof proto.subscribe === 'function') {
+    shimmer.wrap(proto, 'subscribe', fn => function (options, cb) {
+      if (typeof options === 'function') {
+        cb = options
+        options = {}
+      }
+      trueCb = cb
+      const ret = fn.call(this, options, cb)
+      trueCb = null
+      return ret
+    })
+  }
+
+  if (typeof proto.subscribeRaw === 'function') {
+    shimmer.wrap(proto, 'subscribeRaw', fn => function (options, cb) {
+      const queue = this
+
+      if (typeof options === 'function') {
+        cb = options
+        options = {}
+      }
+
+      // Store a reference to the possible true callback,
+      // as it is about to get nulled in queue.subscribe().
+      let refCb = trueCb
+
+      return fn.call(queue, options, function (msg) {
+        const xid = msg && msg.headers && msg.headers.SourceTrace
+
+        if (!refCb) {
+          refCb = queue.consumerTagListeners[msg.consumerTag]
+        }
+
+        return tv.startOrContinueTrace(
+          xid,
+          last => {
+            const { host, port } = queue.connection.options
+            return last.descend('amqp', {
+              Spec: 'job',
+              Flavor: 'amqp',
+              JobName: util.fnName(refCb),
+              RemoteHost: `${host}:${port}`,
+              MsgID: msg.consumerTag,
+              RoutingKey: msg.routingKey,
+              Queue: queue.name,
+            })
+          },
+          (done, layer) => {
+            const ret = cb.call(this, msg)
+            if (!options.noAck && layer) {
+              patchMessage(msg, done, layer)
+            } else {
+              done()
+            }
+            return ret
+          },
+          conf,
+          noop
+        )
+      })
+    })
+  }
+}
+
+function patchMessage (msg, done, layer) {
+  const { exit } = layer.events
+
+  if (typeof msg.acknowledge === 'function') {
+    shimmer.wrap(msg, 'acknowledge', ack => function () {
+      done()
+      exit.Status = 'Acknowledged'
+      return ack.apply(this, arguments)
+    })
+  }
+
+  if (typeof msg.reject === 'function') {
+    shimmer.wrap(msg, 'reject', rej => function () {
+      done()
+      exit.Status = 'Rejected'
+      return rej.apply(this, arguments)
+    })
+  }
 }
 
 const patchedPublish = new WeakMap()
@@ -46,6 +142,7 @@ function patchExchangePublish (exchange) {
   patchedPublish.set(exchange, true)
 
   shimmer.wrap(exchange, 'publish', publish => function (key, msg, opts, cb) {
+    opts = opts || {}
     const {confirm} = this.options
     const runner = confirm
       ? cb => publish.call(this, key, msg, opts, cb)
@@ -53,12 +150,19 @@ function patchExchangePublish (exchange) {
 
     return tv.instrument(last => {
       const { host, port } = this.connection.options
-      return last.descend('amqp', {
+      const layer = last.descend('amqp', {
+        Spec: 'pushq',
+        Flavor: 'amqp',
         RemoteHost: `${host}:${port}`,
         ExchangeName: this.name,
         ExchangeAction: 'publish',
-        RoutingKey: key
+        RoutingKey: key,
+        ExchangeType: this.options.type
       })
+      // Add SourceTrace ID to headers
+      opts.headers = opts.headers || {}
+      opts.headers.SourceTrace = layer.events.entry.toString()
+      return layer
     }, runner, conf, cb)
   })
 }
@@ -87,3 +191,5 @@ module.exports = function (amqp) {
 
   return amqp
 }
+
+function noop () {}

--- a/test/probes/amqp.test.js
+++ b/test/probes/amqp.test.js
@@ -35,6 +35,9 @@ describe('probes.amqp', function () {
       msg.should.have.property('Spec', 'job')
       msg.should.have.property('Flavor', 'amqp')
       msg.should.have.property('MsgID').and.be.an.instanceOf(String)
+      msg.should.have.property('Controller').and.be.an.instanceOf(String)
+      msg.should.have.property('Action').and.be.an.instanceOf(String)
+      msg.should.have.property('URL').and.be.an.instanceOf(String)
     }
   }
 
@@ -196,6 +199,7 @@ describe('probes.amqp', function () {
         msg.should.have.property('Queue', 'queue')
         msg.should.have.property('JobName', 'myJob')
         msg.should.have.property('RoutingKey', 'message')
+        msg.should.have.property('SourceTrace').and.be.an.instanceOf(String)
       },
       function (msg) {
         checks.exit(msg)
@@ -233,6 +237,7 @@ describe('probes.amqp', function () {
         msg.should.have.property('Queue', 'queue')
         msg.should.have.property('JobName', 'myJob')
         msg.should.have.property('RoutingKey', 'message')
+        msg.should.have.property('SourceTrace').and.be.an.instanceOf(String)
       },
       function (msg) {
         checks.exit(msg)

--- a/test/probes/amqp.test.js
+++ b/test/probes/amqp.test.js
@@ -19,11 +19,22 @@ describe('probes.amqp', function () {
     entry: function (msg) {
       msg.should.have.property('Layer', 'amqp')
       msg.should.have.property('Label', 'entry')
-      msg.should.have.property('RemoteHost')
+      msg.should.have.property('Flavor', 'amqp')
+      msg.should.have.property('RemoteHost', db_host)
     },
     exit: function (msg) {
       msg.should.have.property('Layer', 'amqp')
       msg.should.have.property('Label', 'exit')
+    },
+    pushq: function (msg) {
+      msg.should.have.property('Spec', 'pushq')
+      msg.should.have.property('ExchangeAction', 'publish')
+      msg.should.have.property('ExchangeType').and.be.an.instanceOf(String)
+    },
+    job: function (msg) {
+      msg.should.have.property('Spec', 'job')
+      msg.should.have.property('Flavor', 'amqp')
+      msg.should.have.property('MsgID').and.be.an.instanceOf(String)
     }
   }
 
@@ -42,7 +53,7 @@ describe('probes.amqp', function () {
   //
   // Create a connection for the tests to use
   //
-  before(function (done) {
+  beforeEach(function (done) {
     var parts = db_host.split(':')
     var host = parts.shift()
     var port = parts.shift()
@@ -55,7 +66,7 @@ describe('probes.amqp', function () {
     })
     client.on('ready', done)
   })
-  after(function (done) {
+  afterEach(function (done) {
     // NOTE: 1.x has no disconnect() and socket.end() is not safe.
     if (client.disconnect) {
       client.on('close', function () {
@@ -75,7 +86,7 @@ describe('probes.amqp', function () {
       var ex = client.exchange('test', {
         confirm: true
       }, function () {
-        ex.publish('test', {
+        ex.publish('message', {
           foo: 'bar'
         }, {
           mandatory: true
@@ -86,7 +97,9 @@ describe('probes.amqp', function () {
     }, [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('RemoteHost', db_host)
+        checks.pushq(msg)
+        msg.should.have.property('ExchangeName', 'test')
+        msg.should.have.property('RoutingKey', 'message')
       },
       function (msg) {
         checks.exit(msg)
@@ -97,7 +110,7 @@ describe('probes.amqp', function () {
   it('should support no-confirm exchanges', function (done) {
     helper.test(emitter, function (done) {
       var ex = client.exchange('test', {}, function () {
-        var task = ex.publish('test', {
+        var task = ex.publish('message', {
           foo: 'bar'
         })
         done()
@@ -105,8 +118,9 @@ describe('probes.amqp', function () {
     }, [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('RemoteHost', db_host)
+        checks.pushq(msg)
         msg.should.have.property('ExchangeName', 'test')
+        msg.should.have.property('RoutingKey', 'message')
       },
       function (msg) {
         checks.exit(msg)
@@ -122,7 +136,7 @@ describe('probes.amqp', function () {
         q.on('queueBindOk', function() {
           q.on('basicConsumeOk', function () {
             var ex = client.exchange('test', {}, function () {
-              var task = ex.publish('test', {
+              var task = ex.publish('message', {
                 foo: 'bar'
               })
               done()
@@ -139,8 +153,86 @@ describe('probes.amqp', function () {
     }, [
       function (msg) {
         checks.entry(msg)
-        msg.should.have.property('RemoteHost', db_host)
+        checks.pushq(msg)
         msg.should.have.property('ExchangeName', 'test')
+        msg.should.have.property('RoutingKey', 'message')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should report jobs', function (done) {
+    helper.test(emitter, function (done) {
+      var ex = client.exchange('exchange', { type: 'fanout' })
+      client.queue('queue', function (q) {
+        q.bind(ex, '*')
+
+        q.subscribe({ ack: true }, function myJob (a, b, c, msg) {
+          setImmediate(function () {
+            msg.acknowledge()
+            done()
+          })
+        })
+
+        ex.publish('message', {
+          foo: 'bar'
+        })
+      })
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        checks.pushq(msg)
+        msg.should.have.property('ExchangeName', 'exchange')
+        msg.should.have.property('RoutingKey', 'message')
+      },
+      function (msg) {
+        checks.exit(msg)
+      },
+      function (msg) {
+        checks.entry(msg)
+        checks.job(msg)
+        msg.should.have.property('Queue', 'queue')
+        msg.should.have.property('JobName', 'myJob')
+        msg.should.have.property('RoutingKey', 'message')
+      },
+      function (msg) {
+        checks.exit(msg)
+      }
+    ], done)
+  })
+
+  it('should properly report auto-acked jobs', function (done) {
+    helper.test(emitter, function (done) {
+      var ex = client.exchange('exchange', { type: 'fanout' })
+      client.queue('queue', function (q) {
+        q.bind(ex, '')
+
+        q.subscribe({ ack: false }, function myJob () {
+          done()
+        })
+
+        ex.publish('message', {
+          foo: 'bar'
+        })
+      })
+    }, [
+      function (msg) {
+        checks.entry(msg)
+        checks.pushq(msg)
+        msg.should.have.property('ExchangeName', 'exchange')
+        msg.should.have.property('RoutingKey', 'message')
+      },
+      function (msg) {
+        checks.exit(msg)
+      },
+      function (msg) {
+        checks.entry(msg)
+        checks.job(msg)
+        msg.should.have.property('Queue', 'queue')
+        msg.should.have.property('JobName', 'myJob')
+        msg.should.have.property('RoutingKey', 'message')
       },
       function (msg) {
         checks.exit(msg)
@@ -152,7 +244,7 @@ describe('probes.amqp', function () {
     var next = helper.after(2, function () {
       helper.test(emitter, function (done) {
         q.on('basicConsumeOk', function () {
-          var task = ex.publish('test', {
+          var task = ex.publish('message', {
             foo: 'bar'
           })
           done()
@@ -162,14 +254,15 @@ describe('probes.amqp', function () {
           routingKeyInPayload: true
         }, function () {})
       }, [
-      function (msg) {
-        checks.entry(msg)
-        msg.should.have.property('RemoteHost', db_host)
-        msg.should.have.property('ExchangeName', 'test')
-      },
-      function (msg) {
-        checks.exit(msg)
-      }
+        function (msg) {
+          checks.entry(msg)
+          checks.pushq(msg)
+          msg.should.have.property('ExchangeName', 'test')
+          msg.should.have.property('RoutingKey', 'message')
+        },
+        function (msg) {
+          checks.exit(msg)
+        }
       ], done)
     })
 

--- a/test/probes/amqp.test.js
+++ b/test/probes/amqp.test.js
@@ -167,6 +167,7 @@ describe('probes.amqp', function () {
   })
 
   it('should report jobs', function (done) {
+    var id
     helper.test(emitter, function (done) {
       var ex = client.exchange('exchange', { type: 'fanout' })
       client.queue('queue', function (q) {
@@ -189,6 +190,7 @@ describe('probes.amqp', function () {
         checks.pushq(msg)
         msg.should.have.property('ExchangeName', 'exchange')
         msg.should.have.property('RoutingKey', 'message')
+        id = msg['X-Trace']
       },
       function (msg) {
         checks.exit(msg)
@@ -199,7 +201,10 @@ describe('probes.amqp', function () {
         msg.should.have.property('Queue', 'queue')
         msg.should.have.property('JobName', 'myJob')
         msg.should.have.property('RoutingKey', 'message')
-        msg.should.have.property('SourceTrace').and.be.an.instanceOf(String)
+        msg.should.have.property('SourceTrace', id)
+        msg.should.have.property('Controller', 'amqp')
+        msg.should.have.property('Action', 'myJob')
+        msg.should.have.property('URL', '/amqp/queue')
       },
       function (msg) {
         checks.exit(msg)
@@ -208,6 +213,7 @@ describe('probes.amqp', function () {
   })
 
   it('should properly report auto-acked jobs', function (done) {
+    var id
     helper.test(emitter, function (done) {
       var ex = client.exchange('exchange', { type: 'fanout' })
       client.queue('queue', function (q) {
@@ -227,6 +233,7 @@ describe('probes.amqp', function () {
         checks.pushq(msg)
         msg.should.have.property('ExchangeName', 'exchange')
         msg.should.have.property('RoutingKey', 'message')
+        id = msg['X-Trace']
       },
       function (msg) {
         checks.exit(msg)
@@ -237,7 +244,10 @@ describe('probes.amqp', function () {
         msg.should.have.property('Queue', 'queue')
         msg.should.have.property('JobName', 'myJob')
         msg.should.have.property('RoutingKey', 'message')
-        msg.should.have.property('SourceTrace').and.be.an.instanceOf(String)
+        msg.should.have.property('SourceTrace', id)
+        msg.should.have.property('Controller', 'amqp')
+        msg.should.have.property('Action', 'myJob')
+        msg.should.have.property('URL', '/amqp/queue')
       },
       function (msg) {
         checks.exit(msg)


### PR DESCRIPTION
This adds pushq and job spec support to amqp, to track job processing.