### PR TITLE
custom, test: Support startOrContinueTrace with X-TV-Meta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -655,11 +655,19 @@ if (!enabled) {
       return run(cb)
     }
 
+    // Allow destructuring of xtrace, if it is an object
+    let xid = xtrace
+    let meta
+    if (xtrace && typeof xtrace === 'object') {
+      xid = xtrace.xid
+      meta = xtrace.meta
+    }
+
     let sampled
     try {
       // Do sampling
-      const shouldSample = xtrace || exports.always
-      sampled = shouldSample && exports.sample(data.name, xtrace)
+      const shouldSample = xid || exports.always || (exports.through && meta)
+      sampled = shouldSample && exports.sample(data.name, xid, meta)
     } catch (e) {
       error('tv.startOrContinueTrace failed to sample', e.stack)
     }
@@ -671,12 +679,17 @@ if (!enabled) {
     let layer
     try {
       // Now make the actual layer
-      layer = new data.cons(data.name, xtrace, data.data)
+      layer = new data.cons(data.name, xid, data.data)
 
       // Add sampling data to entry
-      if (!xtrace) layer.events.entry.set({
+      if (!xid) layer.events.entry.set({
         SampleSource: exports.sampleSource,
         SampleRate: exports.sampleRate
+      })
+
+      // Set meta, if available
+      if (meta) layer.events.entry.set({
+        'X-TV-Meta': meta
       })
     } catch (e) {
       error('tv.startOrContinueTrace failed to build layer', e.stack)

--- a/lib/index.js
+++ b/lib/index.js
@@ -687,11 +687,6 @@ if (!enabled) {
           SampleRate: exports.sampleRate
         })
       }
-
-      // Set meta, if available
-      if (meta) layer.events.entry.set({
-        'X-TV-Meta': meta
-      })
     } catch (e) {
       error('tv.startOrContinueTrace failed to build layer', e.stack)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -663,11 +663,10 @@ if (!enabled) {
       meta = xtrace.meta
     }
 
+    // Do sampling
     let sampled
     try {
-      // Do sampling
-      const shouldSample = xid || exports.always || (exports.through && meta)
-      sampled = shouldSample && exports.sample(data.name, xid, meta)
+      sampled = exports.sample(data.name, xid, meta)
     } catch (e) {
       error('tv.startOrContinueTrace failed to sample', e.stack)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -681,10 +681,12 @@ if (!enabled) {
       layer = new data.cons(data.name, xid, data.data)
 
       // Add sampling data to entry
-      if (!xid) layer.events.entry.set({
-        SampleSource: exports.sampleSource,
-        SampleRate: exports.sampleRate
-      })
+      if (!exports.always && !xid) {
+        layer.events.entry.set({
+          SampleSource: exports.sampleSource,
+          SampleRate: exports.sampleRate
+        })
+      }
 
       // Set meta, if available
       if (meta) layer.events.entry.set({

--- a/lib/index.js
+++ b/lib/index.js
@@ -681,7 +681,7 @@ if (!enabled) {
       layer = new data.cons(data.name, xid, data.data)
 
       // Add sampling data to entry
-      if (!exports.always && !xid) {
+      if (exports.always && !xid) {
         layer.events.entry.set({
           SampleSource: exports.sampleSource,
           SampleRate: exports.sampleRate

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -569,11 +569,19 @@ describe('custom', function () {
     var entry = previous.events.entry
     var last
 
+    var called = false
+    var sample = tv.sample
+    tv.sample = function (a, b, meta) {
+      tv.sample = sample
+      meta.should.equal(entry.toString())
+      called = true
+      return sample.call(this, a, b, meta)
+    }
+
     helper.doChecks(emitter, [
       function (msg) {
         msg.should.have.property('Layer', 'test')
         msg.should.have.property('Label', 'entry')
-        msg.should.have.property('X-TV-Meta', entry.toString())
         msg.should.have.property('SampleSource')
         msg.should.have.property('SampleRate')
         last = msg['X-Trace'].substr(42)
@@ -583,7 +591,10 @@ describe('custom', function () {
         msg.should.have.property('Label', 'exit')
         msg.Edge.should.equal(last)
       }
-    ], done)
+    ], function (err) {
+      called.should.equal(true)
+      done(err)
+    })
 
     // Clear context
     Layer.last = Event.last = null

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -563,6 +563,40 @@ describe('custom', function () {
     should.not.exist(tv.traceId)
   })
 
+  // Verify start with meta works
+  it('should start with meta', function (done) {
+    var previous = new Layer('previous')
+    var entry = previous.events.entry
+    var last
+
+    helper.doChecks(emitter, [
+      function (msg) {
+        msg.should.have.property('Layer', 'test')
+        msg.should.have.property('Label', 'entry')
+        msg.should.have.property('X-TV-Meta', entry.toString())
+        msg.should.have.property('SampleSource')
+        msg.should.have.property('SampleRate')
+        last = msg['X-Trace'].substr(42)
+      },
+      function (msg) {
+        msg.should.have.property('Layer', 'test')
+        msg.should.have.property('Label', 'exit')
+        msg.Edge.should.equal(last)
+      }
+    ], done)
+
+    // Clear context
+    Layer.last = Event.last = null
+
+    tv.startOrContinueTrace(
+      { meta: entry.toString() },
+      'test',
+      function (cb) { cb() },
+      conf,
+      function () {}
+    )
+  })
+
   it('should bind functions to requestStore', function () {
     var bind = tv.requestStore.bind
     var threw = false


### PR DESCRIPTION
This adds support for passing `X-TV-Meta` values into `tv.startOrContinueTrace(...)`.