### PR TITLE
raw-body: Support promise returns from 2.x

### DIFF
--- a/lib/probes/raw-body.js
+++ b/lib/probes/raw-body.js
@@ -1,20 +1,45 @@
 'use strict'
 
+const requirePatch = require('../require-patch')
+const semver = require('semver')
 const tv = require('..')
 const conf = tv['raw-body']
 
+function addBytes (layer, buf) {
+  try {
+    if (layer && buf && buf.length) {
+      layer.events.exit.RequestBodyBytes = buf.length
+    }
+  } catch (e) {}
+}
+
 function handleExit (layer, done) {
   return function (err, buf) {
-    try {
-      if (layer && buf && buf.length) {
-        layer.events.exit.RequestBodyBytes = buf.length
-      }
-    } catch (e) {}
+    addBytes(layer, buf)
     return done.apply(this, arguments)
   }
 }
 
-module.exports = function (fn) {
+function promiser (fn) {
+  return function (...args) {
+    const last = args[args.length - 1]
+    const cb = typeof last === 'function' ? args.pop() : function () {}
+
+    let layer
+    return tv.instrument(
+      last => (layer = last.descend('body-parser')),
+      done => fn.apply(null, args).then(v => {
+        addBytes(layer, v)
+        done(null, v)
+        return v
+      }, done),
+      conf,
+      cb
+    )
+  }
+}
+
+function thunker (fn) {
   return function (...args) {
     const last = args[args.length - 1]
     const cb = typeof last === 'function' ? args.pop() : null
@@ -28,5 +53,14 @@ module.exports = function (fn) {
     )
 
     return cb ? thunk(cb) : thunk
+  }
+}
+
+module.exports = function (fn) {
+  try {
+    const {version} = requirePatch.relativeRequire('raw-body/package.json')
+    return semver.satisfies(version, '< 2') ? thunker(fn) : promiser(fn)
+  } catch (e) {
+    return fn
   }
 }


### PR DESCRIPTION
This fixes an issue with how co-body uses the newer promise support in raw-body.