### PR TITLE
oboe: Switch to managing contexts in JS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,18 @@ try {
 // Abstract settings with setters and getters
 //
 let traceMode, sampleRate, host, port, accessKey, appToken, _SP
+const settingsContexts = {}
+
+function regenerateContexts() {
+  Object.keys(settingsContexts).forEach(name => {
+    settingsContexts[name] = new bindings.Context(
+      name,
+      appToken,
+      traceMode,
+      sampleRate
+    )
+  })
+}
 
 /**
  * Set appToken
@@ -65,10 +77,10 @@ Object.defineProperty(exports, 'appToken', {
   },
   set (value) {
     log('set app token to ' + value)
-    if (enabled) {
-      bindings.Context.appToken = value
-    }
     appToken = value
+    if (enabled) {
+      regenerateContexts()
+    }
   }
 })
 
@@ -93,11 +105,7 @@ Object.defineProperty(exports, 'accessKey', {
 })
 
 // Helper to map strings to addon keys
-const modeMap = {
-  through: bindings ? bindings.TRACE_THROUGH : 2,
-  always: bindings ? bindings.TRACE_ALWAYS : 1,
-  never: bindings ? bindings.TRACE_NEVER : 0
-}
+const modeMap = [ 'never', 'always', 'through' ]
 
 /**
  * Tracing mode
@@ -109,14 +117,14 @@ const modeMap = {
 Object.defineProperty(exports, 'traceMode', {
   get () { return traceMode },
   set (value) {
-    if (typeof value !== 'number') {
+    if (typeof value === 'number') {
       value = modeMap[value]
     }
     log('set tracing mode to ' + value)
-    if (enabled) {
-      bindings.Context.setTracingMode(value)
-    }
     traceMode = value
+    if (enabled) {
+      regenerateContexts()
+    }
   }
 })
 
@@ -130,10 +138,10 @@ Object.defineProperty(exports, 'sampleRate', {
   get () { return sampleRate },
   set (value) {
     log('set sample rate to ' + value)
-    if (enabled) {
-      bindings.Context.setDefaultSampleRate(value)
-    }
     sampleRate = value
+    if (enabled) {
+      regenerateContexts()
+    }
   }
 })
 
@@ -203,7 +211,7 @@ Object.defineProperty(exports, 'log', {
 
 // Sugar to detect if the current mode is of a particular type
 Object.keys(modeMap).forEach(mode => {
-  Object.defineProperty(exports, mode, {
+  Object.defineProperty(exports, modeMap[mode], {
     get () { return traceMode === modeMap[mode] }
   })
 })
@@ -391,8 +399,16 @@ if (!enabled) {
    * @param {String} meta   x-tv-meta header, if available
    */
   exports.sample = function (layer, xtrace, meta, url) {
-    const rv = bindings.Context.sampleRequest(
-      layer,
+    let ctx = settingsContexts[layer]
+    if (!ctx) {
+      ctx = settingsContexts[layer] = new bindings.Context(
+        layer,
+        appToken,
+        traceMode,
+        sampleRate
+      )
+    }
+    const rv = ctx.shouldSample(
       xtrace || '',
       meta || '',
       url || ''


### PR DESCRIPTION
This updates the app token support to work with the JS-managed context support in https://github.com/appneta/node-traceview-bindings/pull/9.