### PR TITLE
fs, test: Fix realpath test to compensate for node 6.0-6.3 being broken

### DIFF
--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -203,9 +203,9 @@ describe('probes.fs', function () {
       args: ['fs-output/foo.bar.link'],
       // realpath walks up every level of the path and does an lstat at each
       subs: function () {
-        // 6.0.0-rc.* does not satisfy >1.0.0? WAT?
+        // Node 6.0 broke realpath. 6.3 fixed it.
         var v = process.versions.node.split('-').shift()
-        return semver.satisfies(v, '<6', true)
+        return semver.satisfies(v, '<6 || >6.3', true)
           ? resolved.split('/').slice(1).map(function () {
             return span('lstat')
           })


### PR DESCRIPTION
This fixes the fs.realpath test to compensate for the function being broken from node 6.0 to 6.3. See https://github.com/nodejs/node/pull/7899 for more details.