### PR TITLE
mongoose: Ensure addQueue args is an array

### DIFF
--- a/lib/probes/mongoose.js
+++ b/lib/probes/mongoose.js
@@ -39,7 +39,8 @@ module.exports = function (mongoose) {
 
 function patchAddQueue (proto) {
   if (typeof proto.addQueue !== 'function') return
-  shimmer.wrap(proto, 'addQueue', fn => function (name, args) {
+  // NOTE: args may be an arguments object, so [...args] converts to array
+  shimmer.wrap(proto, 'addQueue', fn => function (name, [...args]) {
     args.push(tv.bind(args.pop()))
     return fn.call(this, name, args)
   })


### PR DESCRIPTION
The `args` input to `addQueue(...)` can now potentially be an `arguments` object, so it needs to be converted to an array.